### PR TITLE
106 activity test with clicking are not working on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,13 @@ before_script:
   # Create and start emulator
   - cd Friendly-plans
   - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
-  - emulator -avd test -no-audio -no-window &
+  - emulator -avd test -no-audio &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
 
 script: ./gradlew test --info
 # Turn off because it is not properly working, bug: #106
-script: ./gradlew test connectedAndroidTest --info
+script: ./gradlew test connectedAndroidTest --info --stacktrace
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ android:
 before_script:
   # Create and start emulator
   - cd Friendly-plans
-  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
-  - emulator -avd test -no-skin -no-audio -no-window &
+  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a --skin WXGA800
+  - emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
 
 script: ./gradlew test --info
 # Turn off because it is not properly working, bug: #106
-# script: ./gradlew test connectedAndroidTest --info
+script: ./gradlew test connectedAndroidTest --info
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ before_script:
   - adb shell input keyevent 82 &
 
 script: ./gradlew test --info
-# Turn off because it is not properly working, bug: #106
 script: ./gradlew test connectedAndroidTest --info --stacktrace
 
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   # Create and start emulator
   - cd Friendly-plans
   - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
-  - emulator -avd test -no-skin -no-audio -no-window &
+  - emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   # Create and start emulator
   - cd Friendly-plans
   - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
-  - emulator -avd test -no-audio -no-window &
+  - emulator -avd test -no-skin -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   # Create and start emulator
   - cd Friendly-plans
   - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
-  - emulator -avd test -no-audio &
+  - emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
 

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
@@ -81,13 +81,14 @@ public class TaskCreateActivityTest {
 
     @Test
     public void When_AddingNewTask_Expect_NewTaskAddedToDB() throws InterruptedException {
-//        onView(withId(R.id.id_et_task_name))
-//                .perform(replaceText(EXPECTED_NAME));
-//        closeKeyboard();
-//
-//        onView(withId(R.id.id_et_task_duration_time))
-//                .perform(replaceText("1"));
-//        closeKeyboard();
+
+        onView(withId(R.id.id_et_task_name))
+                .perform(replaceText(EXPECTED_NAME));
+        closeKeyboard();
+
+        onView(withId(R.id.id_et_task_duration_time))
+                .perform(replaceText("1"));
+        closeKeyboard();
 
         onView(withId(R.id.id_btn_task_next))
                 .perform(click());

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
@@ -81,13 +81,13 @@ public class TaskCreateActivityTest {
 
     @Test
     public void When_AddingNewTask_Expect_NewTaskAddedToDB() throws InterruptedException {
-        onView(withId(R.id.id_et_task_name))
-                .perform(replaceText(EXPECTED_NAME));
-        closeKeyboard();
-
-        onView(withId(R.id.id_et_task_duration_time))
-                .perform(replaceText("1"));
-        closeKeyboard();
+//        onView(withId(R.id.id_et_task_name))
+//                .perform(replaceText(EXPECTED_NAME));
+//        closeKeyboard();
+//
+//        onView(withId(R.id.id_et_task_duration_time))
+//                .perform(replaceText("1"));
+//        closeKeyboard();
 
         onView(withId(R.id.id_btn_task_next))
                 .perform(click());

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
@@ -32,7 +32,7 @@ public class TaskCreateActivityTest {
 
     @Rule
     public ActivityTestRule<TaskCreateActivity> activityRule = new ActivityTestRule<>(
-            TaskCreateActivity.class, true, true);
+        TaskCreateActivity.class, true, true);
 
     private static final String EXPECTED_NAME = "TEST TASK";
 
@@ -42,19 +42,20 @@ public class TaskCreateActivityTest {
     @Before
     public void setUp() {
         taskTemplateRepository = new TaskTemplateRepository(
-                daoSessionResource.getSession(activityRule.getActivity().getApplicationContext()));
+            daoSessionResource.getSession(activityRule.getActivity().getApplicationContext()));
     }
 
     @Before
     public void unlockScreen() {
         final TaskCreateActivity activity = activityRule.getActivity();
         Runnable wakeUpDevice = new Runnable() {
-                public void run() {
-                        activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON |
-                                    WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED |
-                                    WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-                    }
-            };
+            public void run() {
+                activity.getWindow().addFlags(
+                    WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
+                        | WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
+                        | WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+            }
+        };
         activity.runOnUiThread(wakeUpDevice);
     }
 
@@ -68,30 +69,30 @@ public class TaskCreateActivityTest {
     @Test
     public void When_TaskCreateActivity_Expect_HeaderAndEmptyFields() {
         onView(withId(R.id.id_task_create_description))
-                .check(matches(withText(R.string.task_create_description)));
+            .check(matches(withText(R.string.task_create_description)));
         onView(withId(R.id.id_et_task_name))
-                .check(matches(withText("")));
+            .check(matches(withText("")));
         onView(withId(R.id.id_et_task_picture))
-                .check(matches(withText("")));
+            .check(matches(withText("")));
         onView(withId(R.id.id_et_task_sound))
-                .check(matches(withText("")));
+            .check(matches(withText("")));
         onView(withId(R.id.id_et_task_duration_time))
-                .check(matches(withText("")));
+            .check(matches(withText("")));
     }
 
     @Test
     public void When_AddingNewTask_Expect_NewTaskAddedToDB() throws InterruptedException {
 
         onView(withId(R.id.id_et_task_name))
-                .perform(replaceText(EXPECTED_NAME));
+            .perform(replaceText(EXPECTED_NAME));
         closeKeyboard();
 
         onView(withId(R.id.id_et_task_duration_time))
-                .perform(replaceText("1"));
+            .perform(replaceText("1"));
         closeKeyboard();
 
         onView(withId(R.id.id_btn_task_next))
-                .perform(click());
+            .perform(click());
 
         List<TaskTemplate> taskTemplates = taskTemplateRepository.get(EXPECTED_NAME);
         idToDelete = taskTemplates.get(0).getId();

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.CoreMatchers.is;
 
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
+import android.view.WindowManager;
 
 import database.repository.TaskTemplateRepository;
 import database.entities.TaskTemplate;
@@ -42,6 +43,19 @@ public class TaskCreateActivityTest {
     public void setUp() {
         taskTemplateRepository = new TaskTemplateRepository(
                 daoSessionResource.getSession(activityRule.getActivity().getApplicationContext()));
+    }
+
+    @Before
+    public void unlockScreen() {
+        final TaskCreateActivity activity = activityRule.getActivity();
+        Runnable wakeUpDevice = new Runnable() {
+                public void run() {
+                        activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON |
+                                    WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED |
+                                    WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+                    }
+            };
+        activity.runOnUiThread(wakeUpDevice);
     }
 
     @After

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
@@ -82,7 +82,6 @@ public class TaskCreateActivityTest {
 
     @Test
     public void When_AddingNewTask_Expect_NewTaskAddedToDB() throws InterruptedException {
-
         onView(withId(R.id.id_et_task_name))
                 .perform(replaceText(EXPECTED_NAME));
         closeKeyboard();

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
@@ -32,7 +32,7 @@ public class TaskCreateActivityTest {
 
     @Rule
     public ActivityTestRule<TaskCreateActivity> activityRule = new ActivityTestRule<>(
-        TaskCreateActivity.class, true, true);
+            TaskCreateActivity.class, true, true);
 
     private static final String EXPECTED_NAME = "TEST TASK";
 
@@ -42,7 +42,7 @@ public class TaskCreateActivityTest {
     @Before
     public void setUp() {
         taskTemplateRepository = new TaskTemplateRepository(
-            daoSessionResource.getSession(activityRule.getActivity().getApplicationContext()));
+                daoSessionResource.getSession(activityRule.getActivity().getApplicationContext()));
     }
 
     @Before
@@ -51,9 +51,9 @@ public class TaskCreateActivityTest {
         Runnable wakeUpDevice = new Runnable() {
             public void run() {
                 activity.getWindow().addFlags(
-                    WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
-                        | WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
-                        | WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+                        WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
+                                | WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
+                                | WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
             }
         };
         activity.runOnUiThread(wakeUpDevice);
@@ -69,30 +69,30 @@ public class TaskCreateActivityTest {
     @Test
     public void When_TaskCreateActivity_Expect_HeaderAndEmptyFields() {
         onView(withId(R.id.id_task_create_description))
-            .check(matches(withText(R.string.task_create_description)));
+                .check(matches(withText(R.string.task_create_description)));
         onView(withId(R.id.id_et_task_name))
-            .check(matches(withText("")));
+                .check(matches(withText("")));
         onView(withId(R.id.id_et_task_picture))
-            .check(matches(withText("")));
+                .check(matches(withText("")));
         onView(withId(R.id.id_et_task_sound))
-            .check(matches(withText("")));
+                .check(matches(withText("")));
         onView(withId(R.id.id_et_task_duration_time))
-            .check(matches(withText("")));
+                .check(matches(withText("")));
     }
 
     @Test
     public void When_AddingNewTask_Expect_NewTaskAddedToDB() throws InterruptedException {
 
         onView(withId(R.id.id_et_task_name))
-            .perform(replaceText(EXPECTED_NAME));
+                .perform(replaceText(EXPECTED_NAME));
         closeKeyboard();
 
         onView(withId(R.id.id_et_task_duration_time))
-            .perform(replaceText("1"));
+                .perform(replaceText("1"));
         closeKeyboard();
 
         onView(withId(R.id.id_btn_task_next))
-            .perform(click());
+                .perform(click());
 
         List<TaskTemplate> taskTemplates = taskTemplateRepository.get(EXPECTED_NAME);
         idToDelete = taskTemplates.get(0).getId();


### PR DESCRIPTION
There are some limitations in Travis' Android support (it's still in beta version) but after some investigation our problem seems to be resolved :)
What was it about? There were two reasons:
1) Screen lock - it may cause issue with message like "matcher couldn't find any root view" or something like that. It's because screen may lock on Android emulator and there is nice workaround for this problem (unlock it in before method).
2) Screen size. Our tests process looks like this:
- get and install dependencies
- create avd (Android Virtual Device)
- run emulator
- run tests
By default skin is for phone size and if we use -no-skin option it choose phone size skin too. So our button is outside of the screen. To fix it I modified script to create avd with tablet skin (it's --skin WXGA800 option, I choose similar size an resolution as they have in Institute) and removed -no-skin opition

Some additional info:
http://stackoverflow.com/questions/32914660/create-an-emulator-with-a-decent-size-from-command-line
https://stuff.mit.edu/afs/sipb/project/android/docs/tools/devices/managing-avds-cmdline.html
http://stackoverflow.com/questions/12846469/how-to-create-android-emulator-in-command-line-with-options
https://github.com/travis-ci/travis-ci/issues/6340
https://developer.android.com/studio/run/managing-avds.html
http://stackoverflow.com/questions/25670535/what-are-the-skin-types-in-android-studio
https://developer.android.com/guide/practices/screens_support.html#testing

PS: Travis doesn't support HAXM so Android emulator is terribly slow. It may cause e.g. problem when during the view change from portrait to landscape mode espresso try to click something and the changing process takes too much time espresso just miss click. It may be resolved with extra waiting time in before method, but with new skin this problem shouldn't appears (screen is in the landscape mode by default).

Plz squash :)