### PR TITLE
Add missing white spaces between hashtags and text 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
-#Contributing to Friendly Plans.
-##About
+# Contributing to Friendly Plans
+## About
 Friendly Plans is an application supporting autism treatment.
 It provides digital version of activity schedules. More about treatment (ENG): [PCDI website](http://www.pcdi.org/resources/videos.html)
 
@@ -12,14 +12,14 @@ The article and short film show the usage of app in Institute for Child Developm
 - [Article](http://iwrd.pl/pl/fundacja/aplikacja-przyjazny-plan-dostepna)
 
 The project was started by students from Gdańsk University of Technology. First version of app is still available in google play store and it's source code is on branch v1.x but it's legacy now. Currently we are working on Friendly Plans 2.0
-##License
+## License
 The project is developing by people who want to make other people's life easier, so Friendly Plans are going to be free to use, download and develop for everybody forever.
 So, except as otherwise noted, this software is licensed under the [GNU General Public License, v3](https://www.gnu.org/licenses/gpl-3.0.txt)
-##Join
+## Join
 If you would like to become a part of community, you are welcome to join and contribute. Your help is needed. It is easy to contact by [project's forum](http://autyzm.eti.pg.gda.pl/forum/) or by conversations in [issues](https://github.com/autyzm-pg/friendly-plans/issues).
-##Workflow
+## Workflow
 In project we are using [GitHub Flow](https://guides.github.com/introduction/flow/). Please make pull requests to master branch.
-##Start
+## Start
 Great place to start are project's [wiki pages](https://github.com/autyzm-pg/friendly-plans/wiki/Getting-started)
 
 Making a long story short:

--- a/doc/Product-requirements.md
+++ b/doc/Product-requirements.md
@@ -6,7 +6,7 @@
 
 ## Main functionalities
 
-###Therapist use case diagram
+### Therapist use case diagram
 ![Therapist use case diagram](therapist-use-cases.jpg)
 
 - As therapist I need to create a plan containg specified tasks for every of children to reach treatment goals.
@@ -17,7 +17,7 @@
 - As therapist I would like to switch between plans easly during its execution and remember where we have finished last time with a progress bar visible with plan on plans list, because children are working with many plans during one session.
 - As therapist I need to give child a break. A break is a special type of task which is pleasant for a child and perceived by the child as a reward. The set of available breaks for plan should be configured by me, and randomly be chosen to display in limited set with size configured per plan.
 
-###Child use case diagram
+### Child use case diagram
 ![Child use case diagram](child-use-cases.jpg)
 
 - As child I want to perform tasks visible on screen to practise exercises.

--- a/doc/code-style-guidelines.md
+++ b/doc/code-style-guidelines.md
@@ -9,7 +9,7 @@ There is one important exception from rules described in Google's document: In p
 ## Database naming guidelines
 Both for table and column names we're using snake_case.
 
-##Android specific guidelines
+## Android specific guidelines
 Guidelines in this paragraph has been taken from (Apache License): [ribot repo](https://github.com/ribot/android-guidelines/blob/master/project_and_code_guidelines.md)
 
 ### Resources files


### PR DESCRIPTION
Add missing white spaces between hashtags and text  to make headers display properly

PS: Please add '#115: ' before my message commit during the merging - I've forgotten about it :P

Closes #115 