### PR TITLE
#227: Update gradle wrapper, gradle and fix dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,31 +7,38 @@ android:
     - tools
     - platform-tools
     - tools
-
     - build-tools-26.0.2
-
-    - android-22  
-    - android-26
-
-    - sys-img-armeabi-v7a-android-26
-
-    # Additional components
+    - android-22
+    - android-24
+    - sys-img-armeabi-v7a-android-22
+      #- sys-img-armeabi-v7a-google_apis-25
     - extra-android-m2repository
-    - extra-google-google_play_services
-    - extra-google-m2repository
-    - addon-google_apis-google-26
+
+
+#before_install:
+#  - mkdir "$ANDROID_HOME/licenses" || true
+#  - echo "$ANDROID_HOME"
+#  - echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
+#  - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
+#  - ls "$ANDROID_HOME"
 
 before_script:
   # Create and start emulator
   - cd Friendly-plans
-  - android list targets
   - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a --skin WXGA800
   - emulator -avd test -no-audio -no-window &
+    #  - echo no | android create avd --force -n test -t android-25 --abi armeabi-v7a --skin WXGA800  --tag google_apis
+    #- QEMU_AUDIO_DRV=none emulator -avd test -no-window &
   - travis_wait 30 android-wait-for-emulator
   - adb shell input keyevent 82 &
 
+#licenses:
+#  - 'android-sdk-preview-license-.+'
+#  - 'android-sdk-license-.+'
+#  - 'google-gdk-license-.+'
+
 script: ./gradlew test --info
-script: ./gradlew test connectedAndroidTest --info --stacktrace
+script: ./gradlew test connectedAndroidTest --info
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ android:
 
     - build-tools-26.0.2
 
+    - android-22  
     - android-26
 
     - sys-img-armeabi-v7a-android-26
@@ -24,7 +25,7 @@ before_script:
   # Create and start emulator
   - cd Friendly-plans
   - android list targets
-  - echo no | android create avd --force -n test -t android-26 --abi armeabi-v7a --skin WXGA800
+  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a --skin WXGA800
   - emulator -avd test -no-audio -no-window &
   - travis_wait 30 android-wait-for-emulator
   - adb shell input keyevent 82 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,11 @@ android:
     - tools
     - platform-tools
     - tools
+
     - build-tools-26.0.2
-    - android-22
+
     - android-26
+
     - sys-img-armeabi-v7a-android-26
 
     # Additional components
@@ -21,7 +23,8 @@ android:
 before_script:
   # Create and start emulator
   - cd Friendly-plans
-  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a --skin WXGA800
+  - android list targets
+  - echo no | android create avd --force -n test -t android-26 --abi armeabi-v7a --skin WXGA800
   - emulator -avd test -no-audio -no-window &
   - travis_wait 30 android-wait-for-emulator
   - adb shell input keyevent 82 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ android:
   components:
     - platform-tools
     - tools
-    - build-tools-24.0.2
+    - build-tools-26.0.2
     - android-22
-    - android-24
+    - android-26
     - sys-img-armeabi-v7a-android-22
     - extra-android-m2repository
 
@@ -17,7 +17,7 @@ before_script:
   - cd Friendly-plans
   - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a --skin WXGA800
   - emulator -avd test -no-audio -no-window &
-  - travis_wait 30 android-wait-for-emulator
+  - android-wait-for-emulator
   - adb shell input keyevent 82 &
 
 script: ./gradlew test --info

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,26 @@ sudo: false
 
 android:
   components:
+    - tools
     - platform-tools
     - tools
     - build-tools-26.0.2
     - android-22
     - android-26
-    - sys-img-armeabi-v7a-android-22
+    - sys-img-armeabi-v7a-android-26
+
+    # Additional components
     - extra-android-m2repository
+    - extra-google-google_play_services
+    - extra-google-m2repository
+    - addon-google_apis-google-26
 
 before_script:
   # Create and start emulator
   - cd Friendly-plans
   - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a --skin WXGA800
   - emulator -avd test -no-audio -no-window &
-  - android-wait-for-emulator
+  - travis_wait 30 android-wait-for-emulator
   - adb shell input keyevent 82 &
 
 script: ./gradlew test --info

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,34 +11,18 @@ android:
     - android-22
     - android-24
     - sys-img-armeabi-v7a-android-22
-      #- sys-img-armeabi-v7a-google_apis-25
     - extra-android-m2repository
-
-
-#before_install:
-#  - mkdir "$ANDROID_HOME/licenses" || true
-#  - echo "$ANDROID_HOME"
-#  - echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
-#  - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
-#  - ls "$ANDROID_HOME"
 
 before_script:
   # Create and start emulator
   - cd Friendly-plans
   - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a --skin WXGA800
   - emulator -avd test -no-audio -no-window &
-    #  - echo no | android create avd --force -n test -t android-25 --abi armeabi-v7a --skin WXGA800  --tag google_apis
-    #- QEMU_AUDIO_DRV=none emulator -avd test -no-window &
   - travis_wait 30 android-wait-for-emulator
   - adb shell input keyevent 82 &
 
-#licenses:
-#  - 'android-sdk-preview-license-.+'
-#  - 'android-sdk-license-.+'
-#  - 'google-gdk-license-.+'
-
-script: ./gradlew test --info
-script: ./gradlew test connectedAndroidTest --info
+script: ./gradlew test
+script: ./gradlew test connectedAndroidTest
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/Friendly-plans/app/build.gradle
+++ b/Friendly-plans/app/build.gradle
@@ -6,13 +6,13 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.greenrobot:greendao-gradle-plugin:3.2.1'
+        classpath 'org.greenrobot:greendao-gradle-plugin:3.2.2'
     }
 }
 
 android {
     compileSdkVersion 24
-    buildToolsVersion '24.0.2'
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId "pg.autyzm.friendly_plans"
@@ -41,6 +41,12 @@ android {
 
     dataBinding {
         enabled = true
+    }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
     }
 
 }

--- a/Friendly-plans/app/build.gradle
+++ b/Friendly-plans/app/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'org.greenrobot.greendao'
 buildscript {
     repositories {
         mavenCentral()
+        google()
     }
     dependencies {
         classpath 'org.greenrobot:greendao-gradle-plugin:3.2.2'
@@ -64,6 +65,9 @@ dependencies {
     compile 'commons-io:commons-io:2.4'
     compile 'org.hamcrest:hamcrest-core:1.3'
     compile 'com.squareup.picasso:picasso:2.5.2'
+    compile 'com.android.databinding:library:1.3.1'
+    compile 'com.android.databinding:adapters:1.3.1'
+
     annotationProcessor "com.google.dagger:dagger-compiler:2.9"
     provided 'javax.annotation:jsr250-api:1.0'
 

--- a/Friendly-plans/build.gradle
+++ b/Friendly-plans/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Friendly-plans/build.gradle
+++ b/Friendly-plans/build.gradle
@@ -16,6 +16,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
         maven {
             url  "http://dl.bintray.com/lukaville/maven"
         }

--- a/Friendly-plans/gradle/wrapper/gradle-wrapper.properties
+++ b/Friendly-plans/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Mar 17 09:06:03 CET 2017
+#Sun Mar 11 21:28:50 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
- Update android build tools (Android plugin)
- Update gradle version
- Update greendao gradle plugin
- Update builTools
- Include Android resources for unitTests (Robolectric guidelines for Android Studio 3.0+)