### PR TITLE
#179: Back to editing task from steps list

### DIFF
--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
@@ -16,6 +16,7 @@ import static org.hamcrest.core.Is.is;
 import static pg.autyzm.friendly_plans.matcher.ErrorTextMatcher.hasErrorText;
 
 import android.content.Context;
+import android.support.test.espresso.Espresso;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.view.WindowManager;
@@ -335,5 +336,40 @@ public class TaskCreateActivityTest {
         closeSoftKeyboard();
         onView(withText(R.string.no_file_to_play_error)).inRoot(new ToastMatcher())
                 .check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void whenMovingBackFromStepListNewTaskCanBeUpdated() {
+        onView(withId(R.id.id_et_task_name))
+                .perform(replaceText(EXPECTED_NAME));
+        closeSoftKeyboard();
+
+        onView(withId(R.id.id_et_task_duration_time))
+                .perform(replaceText(EXPECTED_DURATION_TXT));
+        closeSoftKeyboard();
+
+        onView(withId(R.id.id_btn_steps))
+                .perform(click());
+
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        Espresso.pressBack();
+
+        onView(withId(R.id.id_btn_save_and_finish))
+                .perform(click());
+
+        List<TaskTemplate> taskTemplates = taskTemplateRepository.get(EXPECTED_NAME);
+        idsToDelete.add(taskTemplates.get(0).getId());
+
+        assertThat(taskTemplates.size(), is(1));
+        assertThat(taskTemplates.get(0).getName(), is(EXPECTED_NAME));
+        assertThat(taskTemplates.get(0).getDurationTime(), is(EXPECTED_DURATION));
+        onView(withText(R.string.task_saved_message)).inRoot(new ToastMatcher())
+            .check(matches(isDisplayed()));
+        onView(withId(R.id.button_createPlan)).check(matches(isDisplayed()));
     }
 }

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
@@ -324,6 +324,11 @@ public class TaskCreateActivityTest {
     public void whenFieldsEmptyAndPlayBtnPressedThenToastExpected() {
         onView(withId(R.id.id_btn_play_sound))
                 .perform(click());
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
         onView(withText(R.string.no_file_to_play_error)).inRoot(new ToastMatcher())
                 .check(matches(isDisplayed()));
     }
@@ -355,7 +360,7 @@ public class TaskCreateActivityTest {
                 .perform(click());
 
         try {
-            Thread.sleep(500);
+            Thread.sleep(1000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
@@ -363,7 +368,7 @@ public class TaskCreateActivityTest {
         Espresso.pressBack();
 
         try {
-            Thread.sleep(500);
+            Thread.sleep(1000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
@@ -363,8 +363,6 @@ public class TaskCreateActivityTest {
         assertThat(taskTemplates.size(), is(1));
         assertThat(taskTemplates.get(0).getName(), is(EXPECTED_NAME));
         assertThat(taskTemplates.get(0).getDurationTime(), is(EXPECTED_DURATION));
-        onView(withText(R.string.task_saved_message)).inRoot(new ToastMatcher())
-            .check(matches(isDisplayed()));
         onView(withId(R.id.button_createPlan)).check(matches(isDisplayed()));
     }
 }

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
@@ -148,11 +148,6 @@ public class TaskCreateActivityTest {
         assertThat(taskTemplates.size(), is(1));
         assertThat(taskTemplates.get(0).getName(), is(EXPECTED_NAME));
         assertThat(taskTemplates.get(0).getDurationTime(), is(EXPECTED_DURATION));
-        try {
-            Thread.sleep(500);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
         onView(withId(R.id.button_createPlan)).check(matches(isDisplayed()));
     }
 
@@ -324,11 +319,6 @@ public class TaskCreateActivityTest {
     public void whenFieldsEmptyAndPlayBtnPressedThenToastExpected() {
         onView(withId(R.id.id_btn_play_sound))
                 .perform(click());
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
         onView(withText(R.string.no_file_to_play_error)).inRoot(new ToastMatcher())
                 .check(matches(isDisplayed()));
     }
@@ -359,19 +349,7 @@ public class TaskCreateActivityTest {
         onView(withId(R.id.id_btn_steps))
                 .perform(click());
 
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-
         Espresso.pressBack();
-
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
 
         onView(withId(R.id.id_btn_save_and_finish))
                 .perform(click());

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
@@ -1,5 +1,31 @@
 package pg.autyzm.friendly_plans;
 
+import android.content.Context;
+import android.support.test.espresso.Espresso;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.view.WindowManager;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import database.entities.Asset;
+import database.entities.TaskTemplate;
+import database.repository.AssetRepository;
+import database.repository.TaskTemplateRepository;
+import pg.autyzm.friendly_plans.matcher.ToastMatcher;
+import pg.autyzm.friendly_plans.resource.AssetTestRule;
+import pg.autyzm.friendly_plans.resource.DaoSessionResource;
+import pg.autyzm.friendly_plans.view.task_create.TaskCreateActivity;
+
 import static android.support.test.espresso.Espresso.closeSoftKeyboard;
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
@@ -14,29 +40,6 @@ import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static junit.framework.Assert.assertNull;
 import static org.hamcrest.core.Is.is;
 import static pg.autyzm.friendly_plans.matcher.ErrorTextMatcher.hasErrorText;
-
-import android.content.Context;
-import android.support.test.espresso.Espresso;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
-import android.view.WindowManager;
-import database.entities.Asset;
-import database.entities.TaskTemplate;
-import database.repository.AssetRepository;
-import database.repository.TaskTemplateRepository;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import pg.autyzm.friendly_plans.matcher.ToastMatcher;
-import pg.autyzm.friendly_plans.resource.AssetTestRule;
-import pg.autyzm.friendly_plans.resource.DaoSessionResource;
-import pg.autyzm.friendly_plans.view.task_create.TaskCreateActivity;
 
 @RunWith(AndroidJUnit4.class)
 public class TaskCreateActivityTest {
@@ -352,12 +355,18 @@ public class TaskCreateActivityTest {
                 .perform(click());
 
         try {
-            Thread.sleep(2000);
+            Thread.sleep(500);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
 
         Espresso.pressBack();
+
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
 
         onView(withId(R.id.id_btn_save_and_finish))
                 .perform(click());

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
@@ -48,7 +48,6 @@ public class TaskCreateActivityTest {
     private static final String EXPECTED_DURATION_TXT = "1";
     private static final int EXPECTED_DURATION = 1;
     private static final String BAD_TASK_NAME = "Bad task name!@";
-    private static final String GOOD_TASK_NAME = "good task name";
     private static final String REGEX_TRIM_NAME = "_([\\d]*)(?=\\.)";
 
     @ClassRule
@@ -259,7 +258,7 @@ public class TaskCreateActivityTest {
     @Test
     public void whenAddingNewTaskAndDurationIsEmptyExpectWarning() {
         onView(withId(R.id.id_et_task_name))
-                .perform(typeText(GOOD_TASK_NAME));
+                .perform(typeText(EXPECTED_NAME));
         closeSoftKeyboard();
 
         onView(withId(R.id.id_btn_steps))
@@ -293,10 +292,10 @@ public class TaskCreateActivityTest {
     @Test
     public void whenAddTaskWithExistingNameExpectWarning() {
         idsToDelete.add(taskTemplateRepository
-                .create(GOOD_TASK_NAME, Integer.valueOf(EXPECTED_DURATION_TXT), null, null));
+                .create(EXPECTED_NAME, Integer.valueOf(EXPECTED_DURATION_TXT), null, null));
 
         onView(withId(R.id.id_et_task_name))
-                .perform(typeText(GOOD_TASK_NAME));
+                .perform(typeText(EXPECTED_NAME));
 
         closeSoftKeyboard();
 
@@ -317,6 +316,8 @@ public class TaskCreateActivityTest {
 
     @Test
     public void whenFieldsEmptyAndPlayBtnPressedThenToastExpected() {
+        closeSoftKeyboard();
+
         onView(withId(R.id.id_btn_play_sound))
                 .perform(click());
         onView(withText(R.string.no_file_to_play_error)).inRoot(new ToastMatcher())
@@ -350,6 +351,8 @@ public class TaskCreateActivityTest {
                 .perform(click());
 
         Espresso.pressBack();
+
+        closeSoftKeyboard();
 
         onView(withId(R.id.id_btn_save_and_finish))
                 .perform(click());

--- a/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/view/step_list/StepListFragment.java
+++ b/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/view/step_list/StepListFragment.java
@@ -1,8 +1,8 @@
 package pg.autyzm.friendly_plans.view.step_list;
 
 import android.app.Fragment;
-import android.content.Intent;
 import android.app.FragmentTransaction;
+import android.content.Intent;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.v7.widget.LinearLayoutManager;
@@ -10,15 +10,17 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import database.repository.StepTemplateRepository;
+
 import javax.inject.Inject;
+
+import database.repository.StepTemplateRepository;
 import pg.autyzm.friendly_plans.ActivityProperties;
 import pg.autyzm.friendly_plans.App;
-import pg.autyzm.friendly_plans.view.main_screen.MainActivity;
 import pg.autyzm.friendly_plans.R;
-import pg.autyzm.friendly_plans.view.step_create.StepCreateFragment;
 import pg.autyzm.friendly_plans.databinding.FragmentStepListBinding;
 import pg.autyzm.friendly_plans.notifications.ToastUserNotifier;
+import pg.autyzm.friendly_plans.view.main_screen.MainActivity;
+import pg.autyzm.friendly_plans.view.step_create.StepCreateFragment;
 
 public class StepListFragment extends Fragment implements StepListEvents {
 

--- a/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/view/task_create/TaskCreateFragment.java
+++ b/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/view/task_create/TaskCreateFragment.java
@@ -294,7 +294,7 @@ public class TaskCreateFragment extends Fragment implements TaskCreateActivityEv
 
     @Override
     public void eventListStep(View view) {
-        Long taskId = saveOrUpdate();
+        taskId = saveOrUpdate();
         if (taskId != null) {
             showStepsList(taskId);
         }


### PR DESCRIPTION
Shortest fix ever - removing one word solved the problem. Now taskId is stored in the TaskCreateFragment after switching to steps list view. It allows to go back from steps list and modify task (previously it was creating new task)