### PR TITLE
#249: removing picture and sound after clicking the cross button

### DIFF
--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
@@ -32,6 +32,7 @@ import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.action.ViewActions.replaceText;
 import static android.support.test.espresso.action.ViewActions.scrollTo;
 import static android.support.test.espresso.action.ViewActions.typeText;
+import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.assertThat;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
@@ -333,6 +334,117 @@ public class TaskCreateActivityTest {
         onView(withId(R.id.id_btn_play_sound))
                 .perform(click());
         closeSoftKeyboard();
+        onView(withText(R.string.no_file_to_play_error)).inRoot(new ToastMatcher())
+                .check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void whenImageSelectedAndCrossBtnPressedAndSaveExpectedSaveTaskWithoutImage()
+            throws IOException, InterruptedException {
+
+        onView(withId(R.id.id_et_task_name))
+                .perform(replaceText(EXPECTED_NAME));
+        closeSoftKeyboard();
+
+        onView(withId(R.id.id_et_task_duration_time))
+                .perform(replaceText(EXPECTED_DURATION_TXT));
+        closeSoftKeyboard();
+
+        assetTestRule.setTestPicture();
+        closeSoftKeyboard();
+
+        onView(withId(R.id.id_ib_clear_img_btn))
+                .perform(click());
+        closeSoftKeyboard();
+
+        onView(withId(R.id.id_btn_steps))
+                .perform(click());
+
+        List<Asset> assets = assetRepository.getAll();
+        List<TaskTemplate> taskTemplates = taskTemplateRepository.get(EXPECTED_NAME);
+        idsToDelete.add(taskTemplates.get(0).getId());
+
+        assertThat(taskTemplates.size(), is(1));
+        assertNull(taskTemplates.get(0).getPictureId());
+    }
+
+    @Test
+    public void whenImageSelectedAndCrossBtnPressedExpectedClearPreviewAndEditText()
+            throws IOException, InterruptedException {
+
+        assetTestRule.setTestPicture();
+        closeSoftKeyboard();
+
+        onView(withId(R.id.id_ib_clear_img_btn))
+                .perform(click());
+        closeSoftKeyboard();
+
+        onView(withId(R.id.id_iv_task_picture))
+                .check(doesNotExist());
+
+        onView(withId(R.id.id_et_task_picture))
+                .check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void whenSoundSelectedAndCrossBtnPressedAndSaveExpectedSaveTaskWithoutSound()
+            throws IOException, InterruptedException {
+
+        onView(withId(R.id.id_et_task_name))
+                .perform(replaceText(EXPECTED_NAME));
+        closeSoftKeyboard();
+
+        onView(withId(R.id.id_et_task_duration_time))
+                .perform(replaceText(EXPECTED_DURATION_TXT));
+        closeSoftKeyboard();
+
+        assetTestRule.setTestSound();
+        closeSoftKeyboard();
+
+        onView(withId(R.id.id_ib_clear_sound_btn))
+                .perform(click());
+        closeSoftKeyboard();
+
+        onView(withId(R.id.id_btn_steps))
+                .perform(click());
+
+        List<Asset> assets = assetRepository.getAll();
+        List<TaskTemplate> taskTemplates = taskTemplateRepository.get(EXPECTED_NAME);
+        idsToDelete.add(taskTemplates.get(0).getId());
+
+        assertThat(taskTemplates.size(), is(1));
+        assertNull(taskTemplates.get(0).getSoundId());
+    }
+
+    @Test
+    public void whenSoundSelectedAndCrossBtnPressedExpectedClearEditText()
+            throws IOException, InterruptedException {
+
+        assetTestRule.setTestSound();
+        closeSoftKeyboard();
+
+        onView(withId(R.id.id_ib_clear_sound_btn))
+                .perform(click());
+        closeSoftKeyboard();
+
+        onView(withId(R.id.id_et_task_sound))
+                .check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void whenSoundSelectedAndCrossBtnPressedAndPlayBtnPressedThenToastExpected()
+            throws IOException, InterruptedException {
+
+        assetTestRule.setTestSound();
+        closeSoftKeyboard();
+
+        onView(withId(R.id.id_ib_clear_sound_btn))
+                .perform(click());
+        closeSoftKeyboard();
+
+        onView(withId(R.id.id_btn_play_sound))
+                .perform(click());
+
         onView(withText(R.string.no_file_to_play_error)).inRoot(new ToastMatcher())
                 .check(matches(isDisplayed()));
     }

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
@@ -360,7 +360,6 @@ public class TaskCreateActivityTest {
         onView(withId(R.id.id_btn_steps))
                 .perform(click());
 
-        List<Asset> assets = assetRepository.getAll();
         List<TaskTemplate> taskTemplates = taskTemplateRepository.get(EXPECTED_NAME);
         idsToDelete.add(taskTemplates.get(0).getId());
 
@@ -408,7 +407,6 @@ public class TaskCreateActivityTest {
         onView(withId(R.id.id_btn_steps))
                 .perform(click());
 
-        List<Asset> assets = assetRepository.getAll();
         List<TaskTemplate> taskTemplates = taskTemplateRepository.get(EXPECTED_NAME);
         idsToDelete.add(taskTemplates.get(0).getId());
 

--- a/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/view/task_create/TaskCreateFragment.java
+++ b/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/view/task_create/TaskCreateFragment.java
@@ -44,7 +44,7 @@ import pg.autyzm.friendly_plans.view.components.SoundComponent;
 import pg.autyzm.friendly_plans.view.main_screen.MainActivity;
 import pg.autyzm.friendly_plans.view.step_list.StepListFragment;
 
-public class TaskCreateFragment extends Fragment implements TaskCreateActivityEvents{
+public class TaskCreateFragment extends Fragment implements TaskCreateActivityEvents {
 
     private static final String REGEX_TRIM_NAME = "_([\\d]*)(?=\\.)";
 
@@ -271,9 +271,9 @@ public class TaskCreateFragment extends Fragment implements TaskCreateActivityEv
             showPreview();
         } else {
             taskSound.setText(assetName);
-            soundId = assetId;
-            soundComponent.setSoundId(assetId);
             clearSound.setVisibility(View.VISIBLE);
+            soundId = assetId;
+            soundComponent.setSoundId(soundId);
         }
     }
 
@@ -324,14 +324,17 @@ public class TaskCreateFragment extends Fragment implements TaskCreateActivityEv
     @Override
     public void eventClearPicture(View view) {
         taskPicture.setText("");
-        picturePreview.setImageResource(0);
+        pictureId = null;
+        picturePreview.setImageDrawable(null);
         clearPicture.setVisibility(View.INVISIBLE);
     }
 
     @Override
     public void eventClearSound(View view) {
         taskSound.setText("");
+        soundId = null;
         clearSound.setVisibility(View.INVISIBLE);
+        soundComponent.setSoundId(null);
         soundComponent.stopActions();
     }
 


### PR DESCRIPTION
Actions after clicking the cross button:
- removing value of pictureId and soundId,
- clearing picture preview and sound component.

It resolves #203 and #249.
 