### PR TITLE
#256: Show sound play button only when sound file is selected

### DIFF
--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/StepCreateFragmentTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/StepCreateFragmentTest.java
@@ -201,6 +201,17 @@ public class StepCreateFragmentTest {
             .check(matches(withText(fileName)));
     }
 
+    @Test
+    public void whenAddingSoundPlayAndCrossBtnsAreDisplayed()
+            throws IOException, InterruptedException {
+
+        assetTestRule.setTestSound();
+
+        onView(withId(R.id.id_btn_play_step_sound))
+                .check(matches(isDisplayed()));
+        onView(withId(R.id.id_ib_clear_step_sound_btn))
+                .check(matches(isDisplayed()));
+    }
 
     private void storeStepsToDelete(List<StepTemplate> stepTemplates){
         for (StepTemplate storedStep : stepTemplates) {

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/TaskCreateActivityTest.java
@@ -246,6 +246,18 @@ public class TaskCreateActivityTest {
     }
 
     @Test
+    public void whenAddingSoundPlayAndCrossBtnsAreDisplayed()
+            throws IOException, InterruptedException {
+
+        assetTestRule.setTestSound();
+
+        onView(withId(R.id.id_btn_play_sound))
+                .check(matches(isDisplayed()));
+        onView(withId(R.id.id_ib_clear_sound_btn))
+                .check(matches(isDisplayed()));
+    }
+
+    @Test
     public void whenAddingNewTaskAndNameIsEmptyExpectWarning() {
         closeSoftKeyboard();
         onView(withId(R.id.id_btn_steps))
@@ -313,29 +325,6 @@ public class TaskCreateActivityTest {
         onView(withId(R.id.id_et_task_name))
                 .check(matches(hasErrorText(
                         activityRule.getActivity().getString(R.string.name_exist_msg))));
-    }
-
-    @Test
-    public void whenFieldsEmptyAndPlayBtnPressedThenToastExpected() {
-        closeSoftKeyboard();
-
-        onView(withId(R.id.id_btn_play_sound))
-                .perform(click());
-        onView(withText(R.string.no_file_to_play_error)).inRoot(new ToastMatcher())
-                .check(matches(isDisplayed()));
-    }
-
-    @Test
-    public void whenImageSelectedAndPlayBtnPressedThenToastExpected()
-            throws IOException, InterruptedException {
-
-        assetTestRule.setTestPicture();
-        closeSoftKeyboard();
-        onView(withId(R.id.id_btn_play_sound))
-                .perform(click());
-        closeSoftKeyboard();
-        onView(withText(R.string.no_file_to_play_error)).inRoot(new ToastMatcher())
-                .check(matches(isDisplayed()));
     }
 
     @Test
@@ -426,24 +415,6 @@ public class TaskCreateActivityTest {
         closeSoftKeyboard();
 
         onView(withId(R.id.id_et_task_sound))
-                .check(matches(isDisplayed()));
-    }
-
-    @Test
-    public void whenSoundSelectedAndCrossBtnPressedAndPlayBtnPressedThenToastExpected()
-            throws IOException, InterruptedException {
-
-        assetTestRule.setTestSound();
-        closeSoftKeyboard();
-
-        onView(withId(R.id.id_ib_clear_sound_btn))
-                .perform(click());
-        closeSoftKeyboard();
-
-        onView(withId(R.id.id_btn_play_sound))
-                .perform(click());
-
-        onView(withText(R.string.no_file_to_play_error)).inRoot(new ToastMatcher())
                 .check(matches(isDisplayed()));
     }
 

--- a/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/view/components/SoundComponent.java
+++ b/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/view/components/SoundComponent.java
@@ -70,6 +70,11 @@ public final class SoundComponent {
 
     public void setSoundId(Long soundId){
         this.soundId = soundId;
+        if(soundId == null) {
+            playSoundIcon.setVisibility(View.INVISIBLE);
+        } else {
+            playSoundIcon.setVisibility(View.VISIBLE);
+        }
     }
 
 

--- a/Friendly-plans/app/src/main/res/layout/fragment_step_create.xml
+++ b/Friendly-plans/app/src/main/res/layout/fragment_step_create.xml
@@ -169,6 +169,7 @@
               android:background="@color/transparent"
               android:elevation="1dp"
               android:onClick="@{soundComponent::onPlayStopSoundClick}"
+              android:visibility="invisible"
               android:src="@drawable/ic_play_sound" />
         </RelativeLayout>
 

--- a/Friendly-plans/app/src/main/res/layout/fragment_task_create.xml
+++ b/Friendly-plans/app/src/main/res/layout/fragment_task_create.xml
@@ -195,6 +195,7 @@
               android:adjustViewBounds="true"
               android:layout_marginStart="40dp"
               android:background="@color/transparent"
+              android:visibility="invisible"
               android:elevation="1dp"
               android:onClick="@{soundComponent::onPlayStopSoundClick}"
               android:src="@drawable/ic_play_sound" />


### PR DESCRIPTION
- sound play button is initially hidden,
- when sound is added button is displayed
- removed tests related to pressing play button while sound isn't selected,
- added test checkinf if the button is displayed after selecting the sound file.

Resolves issue #256 