### PR TITLE
#263: Clicking cross button clears SoundComponent in step create

### DIFF
--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/StepCreateFragmentTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/StepCreateFragmentTest.java
@@ -25,7 +25,6 @@ import database.entities.StepTemplate;
 import database.repository.AssetRepository;
 import database.repository.StepTemplateRepository;
 import database.repository.TaskTemplateRepository;
-import pg.autyzm.friendly_plans.matcher.ToastMatcher;
 import pg.autyzm.friendly_plans.resource.AssetTestRule;
 import pg.autyzm.friendly_plans.resource.DaoSessionResource;
 import pg.autyzm.friendly_plans.view.step_create.StepCreateFragment;
@@ -42,6 +41,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static junit.framework.Assert.assertNull;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
 
 @RunWith(AndroidJUnit4.class)
 public class StepCreateFragmentTest {
@@ -212,6 +212,22 @@ public class StepCreateFragmentTest {
         onView(withId(R.id.id_ib_clear_step_sound_btn))
                 .check(matches(isDisplayed()));
     }
+
+    @Test
+    public void whenSoundCrossBtnIsPressedPlayAndCrossBtnsAreNotDisplayed()
+            throws IOException, InterruptedException {
+
+        assetTestRule.setTestSound();
+
+        onView(withId(R.id.id_ib_clear_step_sound_btn))
+                .perform(click());
+
+        onView(withId(R.id.id_btn_play_step_sound))
+                .check(matches(not(isDisplayed())));
+        onView(withId(R.id.id_ib_clear_step_sound_btn))
+                .check(matches(not(isDisplayed())));
+    }
+
 
     private void storeStepsToDelete(List<StepTemplate> stepTemplates){
         for (StepTemplate storedStep : stepTemplates) {

--- a/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/view/step_create/StepCreateFragment.java
+++ b/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/view/step_create/StepCreateFragment.java
@@ -231,8 +231,11 @@ public class StepCreateFragment extends Fragment implements StepCreateEvents.Ste
     @Override
     public void clearStepSound() {
         stepSound.setText("");
-        clearSound.setVisibility(View.INVISIBLE);
         soundId = null;
+        clearSound.setVisibility(View.INVISIBLE);
+        soundComponent.setSoundId(null);
+        soundComponent.stopActions();
+
     }
 
     @Override


### PR DESCRIPTION
- modified StepCreateFragment to clear SoundComponent's SoundId
- added test which verifies if Play and Cross buttons are hidden after clicking Cross button 