### PR TITLE
#300: refreshing lists after back from edit

### DIFF
--- a/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/view/plan_list/PlanListActivity.java
+++ b/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/view/plan_list/PlanListActivity.java
@@ -78,6 +78,12 @@ public class PlanListActivity extends AppCompatActivity {
         });
     }
 
+    @Override
+    protected void onRestart() {
+        super.onRestart();
+        planListAdapter.setPlanItems(planTemplateRepository.getAll());
+    }
+
     private void setUpViews() {
         RecyclerView recyclerView = (RecyclerView) findViewById(R.id.rv_plan_list);
         recyclerView.setHasFixedSize(true);

--- a/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/view/task_list/TaskListActivity.java
+++ b/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/view/task_list/TaskListActivity.java
@@ -42,6 +42,12 @@ public class TaskListActivity extends AppCompatActivity {
         taskListAdapter.setTaskItems(taskTemplateRepository.getAll());
     }
 
+    @Override
+    protected void onRestart() {
+        super.onRestart();
+        taskListAdapter.setTaskItems(taskTemplateRepository.getAll());
+    }
+
     private void setUpViews() {
         RecyclerView recyclerView = (RecyclerView) findViewById(R.id.rv_task_list);
         recyclerView.setHasFixedSize(true);


### PR DESCRIPTION
Added onRestart() methods to TaskListActivity and PlanListActivity, in which I refresh the content of the list. 
OnRestart() executes when activity is restarted after being stopped by moving to the "Plan/Task Create" one, as explained in-depth here [https://developer.android.com/...](https://developer.android.com/guide/components/activities/activity-lifecycle)

Lists should now refresh correctly when going back to them after plan/task update.
Some tests fail randomly, but they seem to be unrelated to this changes as far as I can tell. Would be grateful if someone tested it as well though.