### PR TITLE
 #290: Allows to add tasks to the plan

### DIFF
--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanCreateActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanCreateActivityTest.java
@@ -1,24 +1,10 @@
 package pg.autyzm.friendly_plans.manager_app;
 
-import static android.support.test.espresso.Espresso.closeSoftKeyboard;
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.action.ViewActions.replaceText;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.assertThat;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
-import static org.hamcrest.core.Is.is;
-
 import android.content.Context;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.view.WindowManager;
-import database.entities.PlanTemplate;
-import database.repository.PlanTemplateRepository;
-import java.util.ArrayList;
-import java.util.List;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -26,10 +12,25 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import database.entities.PlanTemplate;
+import database.repository.PlanTemplateRepository;
 import pg.autyzm.friendly_plans.R;
-import pg.autyzm.friendly_plans.matcher.ToastMatcher;
-import pg.autyzm.friendly_plans.resource.DaoSessionResource;
 import pg.autyzm.friendly_plans.manager_app.view.plan_create.PlanCreateActivity;
+import pg.autyzm.friendly_plans.resource.DaoSessionResource;
+
+import static android.support.test.espresso.Espresso.closeSoftKeyboard;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.replaceText;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.assertThat;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.core.Is.is;
+import static pg.autyzm.friendly_plans.matcher.ErrorTextMatcher.hasErrorText;
 
 @RunWith(AndroidJUnit4.class)
 public class PlanCreateActivityTest {
@@ -110,10 +111,10 @@ public class PlanCreateActivityTest {
         onView(withId(R.id.id_btn_plan_next))
                 .perform(click());
 
-        closeSoftKeyboard();
 
-        onView(withText(R.string.name_exist_msg)).inRoot(new ToastMatcher())
-                .check(matches(isDisplayed()));
+        onView(withId(R.id.id_et_plan_name))
+                .check(matches(hasErrorText(
+                        activityRule.getActivity().getString(R.string.name_exist_msg))));
 
         List<PlanTemplate> planTemplates = planTemplateRepository.get(DUPLICATED_NAME);
         assertThat(planTemplates.size(), is(1));

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanListActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanListActivityTest.java
@@ -154,13 +154,14 @@ public class PlanListActivityTest {
     public void whenSearchPlanIsRemovedExpectItToBeRemoved(){
         final int testedPlanPosition = 5;
 
-        onView(withId(R.id.menu_search)).perform(click());
         onView(withId(R.id.menu_search)).perform(typeText(expectedName + testedPlanPosition));
+
         onView(withId(R.id.rv_plan_list))
                 .perform(RecyclerViewActions
                         .actionOnItemAtPosition(0,
                                 clickChildViewWithId(R.id.id_remove_plan)));
         onView(isAssignableFrom(EditText.class)).perform(clearText());
+        closeSoftKeyboard();
 
         onView(withId(R.id.rv_plan_list)).perform(scrollToPosition(testedPlanPosition));
         onView(withRecyclerView(R.id.rv_plan_list)

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanTaskListFragmentTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanTaskListFragmentTest.java
@@ -1,16 +1,15 @@
 package pg.autyzm.friendly_plans.manager_app;
 
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
-
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
+import android.os.Bundle;
+import android.support.test.espresso.contrib.RecyclerViewActions;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
+import android.support.v7.widget.RecyclerView;
+
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,28 +17,86 @@ import org.junit.runner.RunWith;
 import pg.autyzm.friendly_plans.R;
 import pg.autyzm.friendly_plans.manager_app.view.plan_create.PlanCreateActivity;
 import pg.autyzm.friendly_plans.manager_app.view.plan_create_task_list.PlanTaskListFragment;
+import pg.autyzm.friendly_plans.resource.DaoSessionResource;
+import pg.autyzm.friendly_plans.resource.PlanTemplateRule;
+import pg.autyzm.friendly_plans.resource.TaskTemplateRule;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.hasDescendant;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static pg.autyzm.friendly_plans.matcher.RecyclerViewMatcher.withRecyclerView;
 
 @RunWith(AndroidJUnit4.class)
 public class PlanTaskListFragmentTest {
+
+    private static final String PLAN_ID = "PLAN_ID";
+    private static final String TASK_NAME = "TASK_NAME";
+    private static final String PLAN_NAME = "PLAN NAME";
+
+    @ClassRule
+    public static DaoSessionResource daoSessionResource = new DaoSessionResource();
 
     @Rule
     public ActivityTestRule<PlanCreateActivity> activityRule = new ActivityTestRule<>(
             PlanCreateActivity.class, true, true);
 
+    @Rule
+    public PlanTemplateRule planTemplateRule = new PlanTemplateRule(daoSessionResource,
+            activityRule);
+
+    @Rule
+    public TaskTemplateRule taskTemplateRule = new TaskTemplateRule(daoSessionResource,
+            activityRule);
+
     @Before
     public void setUp() {
         PlanTaskListFragment fragment = new PlanTaskListFragment();
+
+        taskTemplateRule.createTask(TASK_NAME);
+        long planId = planTemplateRule.createPlan(PLAN_NAME);
+
+        Bundle args = new Bundle();
+        args.putLong(PLAN_ID, planId);
+        fragment.setArguments(args);
 
         FragmentManager manager = activityRule.getActivity().getFragmentManager();
         FragmentTransaction transaction = manager.beginTransaction();
         transaction.replace(R.id.plan_container, fragment);
         transaction.commit();
     }
+
     @Test
     public void whenPlanTaskListFragmentExpectHeaderAndButtons() {
         onView(withId(R.id.id_tv_plan_tasks_list_info))
                 .check(matches(withText(R.string.create_plan_tasks_list_info)));
         onView(withId(R.id.id_btn_create_plan_add_tasks)).check(matches(isDisplayed()));
         onView(withId(R.id.id_btn_save_plan_tasks)).check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void whenAddingNewTaskToPlanExpectShowTaskOnList() {
+        onView(withId(R.id.id_btn_create_plan_add_tasks))
+            .perform(click());
+
+        RecyclerView recyclerView = (RecyclerView) activityRule.getActivity().findViewById(R.id.rv_create_plan_add_tasks);
+        int lastPosition = recyclerView.getAdapter().getItemCount() - 1;
+
+        onView(withId(R.id.rv_create_plan_add_tasks)).perform(
+                RecyclerViewActions.scrollToPosition(lastPosition));
+
+        onView(withId(R.id.rv_create_plan_add_tasks)).perform(
+                RecyclerViewActions
+                        .actionOnItemAtPosition(lastPosition, click()));
+
+        onView(withId(R.id.id_btn_add_tasks_to_plan))
+                .perform(click());
+
+        onView(withRecyclerView(R.id.rv_create_plan_task_list)
+                .atPosition(0))
+                .check(matches(hasDescendant(withText(TASK_NAME))));
     }
 }

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/TaskListActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/TaskListActivityTest.java
@@ -11,10 +11,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import database.repository.TaskTemplateRepository;
 import pg.autyzm.friendly_plans.R;
-import pg.autyzm.friendly_plans.resource.DaoSessionResource;
 import pg.autyzm.friendly_plans.manager_app.view.task_list.TaskListActivity;
+import pg.autyzm.friendly_plans.resource.DaoSessionResource;
 import pg.autyzm.friendly_plans.resource.TaskTemplateRule;
 
 import static android.support.test.espresso.Espresso.onView;

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/TaskListActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/TaskListActivityTest.java
@@ -15,6 +15,7 @@ import database.repository.TaskTemplateRepository;
 import pg.autyzm.friendly_plans.R;
 import pg.autyzm.friendly_plans.resource.DaoSessionResource;
 import pg.autyzm.friendly_plans.manager_app.view.task_list.TaskListActivity;
+import pg.autyzm.friendly_plans.resource.TaskTemplateRule;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
@@ -31,21 +32,20 @@ public class TaskListActivityTest {
     private static final String expectedName = "TEST TASK ";
     @ClassRule
     public static DaoSessionResource daoSessionResource = new DaoSessionResource();
+
     @Rule
     public ActivityTestRule<TaskListActivity> activityRule = new ActivityTestRule<>(
             TaskListActivity.class, true, true);
 
+    @Rule
+    public TaskTemplateRule taskTemplateRule = new TaskTemplateRule(daoSessionResource,
+            activityRule);
+
     @Before
     public void setUp() {
         final int numberOfTasks = 10;
-        TaskTemplateRepository taskTemplateRepository = new TaskTemplateRepository(
-                daoSessionResource.getSession(activityRule.getActivity().getApplicationContext()));
-        taskTemplateRepository.deleteAll();
         for (int taskNumber = 0; taskNumber < numberOfTasks; taskNumber++) {
-            taskTemplateRepository
-                    .create(expectedName + taskNumber,
-                            taskNumber, (long) taskNumber,
-                            (long) taskNumber);
+            taskTemplateRule.createTask(expectedName + taskNumber);
         }
         activityRule.launchActivity(new Intent());
     }

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/resource/PlanTemplateRule.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/resource/PlanTemplateRule.java
@@ -1,0 +1,73 @@
+package pg.autyzm.friendly_plans.resource;
+
+import android.content.Context;
+import android.support.test.rule.ActivityTestRule;
+
+import org.junit.rules.ExternalResource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import database.entities.PlanTemplate;
+import database.repository.PlanTemplateRepository;
+import database.repository.TaskTemplateRepository;
+
+public class PlanTemplateRule extends ExternalResource {
+
+    private final DaoSessionResource daoSessionResource;
+    private final ActivityTestRule activityRule;
+
+    private PlanTemplateRepository planTemplateRepository;
+    private TaskTemplateRepository taskTemplateRepository;
+
+    private List<Long> planIds = new ArrayList<>();
+    private List<Long> taskIds = new ArrayList<>();
+
+    public PlanTemplateRule(DaoSessionResource daoSessionResource, ActivityTestRule activityRule) {
+        this.daoSessionResource = daoSessionResource;
+        this.activityRule = activityRule;
+    }
+
+    public long createPlan(String planName) {
+        Context context = activityRule.getActivity().getApplicationContext();
+        planTemplateRepository = new PlanTemplateRepository(daoSessionResource.getSession(context));
+
+        long planId = planTemplateRepository.create(planName);
+        planIds.add(planId);
+
+        return planId;
+    }
+
+    public long createPlanWithTasksSteps(String planName, String taskName1, String taskName2) {
+        Context context = activityRule.getActivity().getApplicationContext();
+        planTemplateRepository = new PlanTemplateRepository(daoSessionResource.getSession(context));
+        taskTemplateRepository = new TaskTemplateRepository(daoSessionResource.getSession(context));
+
+        long planId = planTemplateRepository.create(planName);
+        planIds.add(planId);
+
+        PlanTemplate planTemplate = planTemplateRepository.get(planId);
+
+        long taksId1 = taskTemplateRepository.create(taskName1, 2, null, null);
+        long taksId2 = taskTemplateRepository.create(taskName2, 2, null, null);
+        taskIds.add(taksId1);
+        taskIds.add(taksId2);
+        planTemplate.setTasksWithThisPlan(taskTemplateRepository.get(taksId1));
+        planTemplate.setTasksWithThisPlan(taskTemplateRepository.get(taksId2));
+
+        return planId;
+    }
+
+    @Override
+    protected void after() {
+        for (Long planId : planIds) {
+            PlanTemplate planTemplate = planTemplateRepository.get(planId);
+            planTemplate.resetTasksWithThisPlan();
+            planTemplateRepository.delete(planId);
+        }
+
+        for (Long taskId : taskIds) {
+            taskTemplateRepository.delete(taskId);
+        }
+    }
+}

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/resource/PlanTemplateRule.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/resource/PlanTemplateRule.java
@@ -46,14 +46,12 @@ public class PlanTemplateRule extends ExternalResource {
         long planId = planTemplateRepository.create(planName);
         planIds.add(planId);
 
-        PlanTemplate planTemplate = planTemplateRepository.get(planId);
-
         long taksId1 = taskTemplateRepository.create(taskName1, 2, null, null);
         long taksId2 = taskTemplateRepository.create(taskName2, 2, null, null);
         taskIds.add(taksId1);
         taskIds.add(taksId2);
-        planTemplate.setTasksWithThisPlan(taskTemplateRepository.get(taksId1));
-        planTemplate.setTasksWithThisPlan(taskTemplateRepository.get(taksId2));
+        planTemplateRepository.setTasksWithThisPlan(planId, taksId1);
+        planTemplateRepository.setTasksWithThisPlan(planId, taksId2);
 
         return planId;
     }

--- a/Friendly-plans/app/src/main/java/database/entities/PlanTemplate.java
+++ b/Friendly-plans/app/src/main/java/database/entities/PlanTemplate.java
@@ -1,13 +1,13 @@
 package database.entities;
 
+import org.greenrobot.greendao.DaoException;
 import org.greenrobot.greendao.annotation.Entity;
+import org.greenrobot.greendao.annotation.Generated;
 import org.greenrobot.greendao.annotation.Id;
+import org.greenrobot.greendao.annotation.JoinEntity;
 import org.greenrobot.greendao.annotation.ToMany;
 
 import java.util.List;
-
-import org.greenrobot.greendao.annotation.Generated;
-import org.greenrobot.greendao.DaoException;
 
 @Entity
 public class PlanTemplate {
@@ -22,6 +22,14 @@ public class PlanTemplate {
 
     @ToMany(referencedJoinProperty = "planTemplateId")
     private List<PlanTaskTemplate> planTaskTemplates;
+
+    @ToMany
+    @JoinEntity(
+            entity = PlanTaskTemplate.class,
+            sourceProperty = "planTemplateId",
+            targetProperty = "taskTemplateId"
+    )
+    private List<TaskTemplate> tasksWithThisPlan;
 
     /**
      * Used to resolve relations
@@ -60,6 +68,18 @@ public class PlanTemplate {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public void setTasksWithThisPlan(TaskTemplate task) {
+        PlanTaskTemplate planTaskTemplate = new PlanTaskTemplate();
+        planTaskTemplate.setTaskTemplateId(task.getId());
+        planTaskTemplate.setPlanTemplateId(id);
+
+        PlanTaskTemplateDao targetDao = daoSession.getPlanTaskTemplateDao();
+        targetDao.insert(planTaskTemplate);
+
+        if (tasksWithThisPlan == null) { getTasksWithThisPlan(); }
+        tasksWithThisPlan.add(task);
     }
 
     /**
@@ -158,6 +178,35 @@ public class PlanTemplate {
             throw new DaoException("Entity is detached from DAO context");
         }
         myDao.update(this);
+    }
+
+    /**
+     * To-many relationship, resolved on first access (and after reset).
+     * Changes to to-many relations are not persisted, make changes to the target entity.
+     */
+    @Generated(hash = 2083683117)
+    public List<TaskTemplate> getTasksWithThisPlan() {
+        if (tasksWithThisPlan == null) {
+            final DaoSession daoSession = this.daoSession;
+            if (daoSession == null) {
+                throw new DaoException("Entity is detached from DAO context");
+            }
+            TaskTemplateDao targetDao = daoSession.getTaskTemplateDao();
+            List<TaskTemplate> tasksWithThisPlanNew = targetDao
+                    ._queryPlanTemplate_TasksWithThisPlan(id);
+            synchronized (this) {
+                if (tasksWithThisPlan == null) {
+                    tasksWithThisPlan = tasksWithThisPlanNew;
+                }
+            }
+        }
+        return tasksWithThisPlan;
+    }
+
+    /** Resets a to-many relationship, making the next get call to query for a fresh result. */
+    @Generated(hash = 832786472)
+    public synchronized void resetTasksWithThisPlan() {
+        tasksWithThisPlan = null;
     }
 
     /** called by internal mechanisms, do not call yourself. */

--- a/Friendly-plans/app/src/main/java/database/entities/PlanTemplate.java
+++ b/Friendly-plans/app/src/main/java/database/entities/PlanTemplate.java
@@ -70,18 +70,6 @@ public class PlanTemplate {
         this.name = name;
     }
 
-    public void setTasksWithThisPlan(TaskTemplate task) {
-        PlanTaskTemplate planTaskTemplate = new PlanTaskTemplate();
-        planTaskTemplate.setTaskTemplateId(task.getId());
-        planTaskTemplate.setPlanTemplateId(id);
-
-        PlanTaskTemplateDao targetDao = daoSession.getPlanTaskTemplateDao();
-        targetDao.insert(planTaskTemplate);
-
-        if (tasksWithThisPlan == null) { getTasksWithThisPlan(); }
-        tasksWithThisPlan.add(task);
-    }
-
     /**
      * To-many relationship, resolved on first access (and after reset). Changes to to-many
      * relations are not persisted, make changes to the target entity.

--- a/Friendly-plans/app/src/main/java/database/repository/PlanTemplateRepository.java
+++ b/Friendly-plans/app/src/main/java/database/repository/PlanTemplateRepository.java
@@ -1,9 +1,12 @@
 package database.repository;
 
+import java.util.List;
+
 import database.entities.DaoSession;
+import database.entities.PlanTaskTemplate;
+import database.entities.PlanTaskTemplateDao;
 import database.entities.PlanTemplate;
 import database.entities.PlanTemplateDao;
-import java.util.List;
 
 
 public class PlanTemplateRepository {
@@ -27,6 +30,17 @@ public class PlanTemplateRepository {
         daoSession.getPlanTemplateDao().update(planTemplate);
     }
 
+
+    public void setTasksWithThisPlan(Long planId, Long taskId) {
+        PlanTaskTemplate planTaskTemplate = new PlanTaskTemplate();
+        planTaskTemplate.setTaskTemplateId(taskId);
+        planTaskTemplate.setPlanTemplateId(planId);
+
+        PlanTaskTemplateDao targetDao = daoSession.getPlanTaskTemplateDao();
+        targetDao.insert(planTaskTemplate);
+
+        get(planId).resetTasksWithThisPlan();
+    }
 
     public PlanTemplate get(Long id) {
         return daoSession.getPlanTemplateDao().load(id);

--- a/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/plan_create_add_tasks/AddTasksToPlanEvents.java
+++ b/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/plan_create_add_tasks/AddTasksToPlanEvents.java
@@ -1,0 +1,10 @@
+package pg.autyzm.friendly_plans.manager_app.view.plan_create_add_tasks;
+
+
+import android.view.View;
+
+public interface AddTasksToPlanEvents {
+
+    void eventDoneAddingTasksToPlan(View view);
+
+}

--- a/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/plan_create_add_tasks/AddTasksToPlanFragment.java
+++ b/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/plan_create_add_tasks/AddTasksToPlanFragment.java
@@ -4,14 +4,54 @@ package pg.autyzm.friendly_plans.manager_app.view.plan_create_add_tasks;
 import android.app.Fragment;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import database.entities.PlanTemplate;
+import database.entities.TaskTemplate;
+import database.repository.PlanTemplateRepository;
+import database.repository.TaskTemplateRepository;
+import pg.autyzm.friendly_plans.ActivityProperties;
 import pg.autyzm.friendly_plans.App;
 import pg.autyzm.friendly_plans.R;
 import pg.autyzm.friendly_plans.databinding.FragmentAddTasksToPlanBinding;
+import pg.autyzm.friendly_plans.manager_app.view.task_list.TaskRecyclerViewAdapter;
 
-public class AddTasksToPlanFragment extends Fragment {
+public class AddTasksToPlanFragment extends Fragment implements AddTasksToPlanEvents{
+
+    private TaskRecyclerViewAdapter taskListAdapter;
+
+    @Inject
+    TaskTemplateRepository taskTemplateRepository;
+
+    @Inject
+    PlanTemplateRepository planTemplateRepository;
+
+    Long planId;
+
+    TaskRecyclerViewAdapter.TaskItemClickListener taskItemClickListener =
+            new TaskRecyclerViewAdapter.TaskItemClickListener() {
+                @Override
+                public void onTaskItemClick(int position) {
+                    PlanTemplate planTemplate = planTemplateRepository.get(planId);
+                    planTemplate.setTasksWithThisPlan(
+                            taskTemplateRepository.get(
+                                    taskListAdapter.getTaskItem(position).getId()
+                            )
+                    );
+                    taskListAdapter.removeListItem(position);
+
+                }
+            };
+
+
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
@@ -21,7 +61,38 @@ public class AddTasksToPlanFragment extends Fragment {
         FragmentAddTasksToPlanBinding binding = DataBindingUtil.inflate(
                 inflater, R.layout.fragment_add_tasks_to_plan, container, false);
 
+        binding.setAddTasksToPlanEvents(this);
+
         View view = binding.getRoot();
         return view;
+    }
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        Bundle arguments = getArguments();
+        if (arguments != null && arguments.containsKey(ActivityProperties.PLAN_ID)) {
+            planId = (Long) arguments.get(ActivityProperties.PLAN_ID);
+        }
+
+        RecyclerView recyclerView = (RecyclerView) getActivity().findViewById(R.id.rv_create_plan_add_tasks);
+        recyclerView.setHasFixedSize(true);
+        recyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
+        taskListAdapter = new TaskRecyclerViewAdapter(taskItemClickListener);
+        recyclerView.setAdapter(taskListAdapter);
+
+        /* Show only tasks that are not already added to current plan */
+        PlanTemplate planTemplate = planTemplateRepository.get(planId);
+        List<TaskTemplate> tasks =  taskTemplateRepository.getAll();
+
+        if(planTemplate != null) {
+            tasks.removeAll(planTemplate.getTasksWithThisPlan());
+        }
+
+        taskListAdapter.setTaskItems(tasks);
+    }
+
+    @Override
+    public void eventDoneAddingTasksToPlan(View view) {
+        getFragmentManager().popBackStack();
     }
 }

--- a/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/plan_create_add_tasks/AddTasksToPlanFragment.java
+++ b/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/plan_create_add_tasks/AddTasksToPlanFragment.java
@@ -40,12 +40,7 @@ public class AddTasksToPlanFragment extends Fragment implements AddTasksToPlanEv
             new TaskRecyclerViewAdapter.TaskItemClickListener() {
                 @Override
                 public void onTaskItemClick(int position) {
-                    PlanTemplate planTemplate = planTemplateRepository.get(planId);
-                    planTemplate.setTasksWithThisPlan(
-                            taskTemplateRepository.get(
-                                    taskListAdapter.getTaskItem(position).getId()
-                            )
-                    );
+                    planTemplateRepository.setTasksWithThisPlan(planId, taskListAdapter.getTaskItem(position).getId());
                     taskListAdapter.removeListItem(position);
 
                 }

--- a/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/plan_create_task_list/PlanTaskListFragment.java
+++ b/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/plan_create_task_list/PlanTaskListFragment.java
@@ -4,15 +4,38 @@ import android.app.Fragment;
 import android.app.FragmentTransaction;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+
+import javax.inject.Inject;
+
+import database.entities.PlanTemplate;
+import database.repository.PlanTemplateRepository;
+import pg.autyzm.friendly_plans.ActivityProperties;
 import pg.autyzm.friendly_plans.App;
 import pg.autyzm.friendly_plans.R;
 import pg.autyzm.friendly_plans.databinding.FragmentPlanTaskListBinding;
 import pg.autyzm.friendly_plans.manager_app.view.plan_create_add_tasks.AddTasksToPlanFragment;
+import pg.autyzm.friendly_plans.manager_app.view.task_list.TaskRecyclerViewAdapter;
 
 public class PlanTaskListFragment extends Fragment implements PlanTaskListEvents {
+
+    private TaskRecyclerViewAdapter taskListAdapter;
+    private Long planId;
+
+    @Inject
+    PlanTemplateRepository planTemplateRepository;
+
+    TaskRecyclerViewAdapter.TaskItemClickListener taskItemClickListener =
+            new TaskRecyclerViewAdapter.TaskItemClickListener() {
+                @Override
+                public void onTaskItemClick(int position) {
+                    /* What to do after click? Remove task? Edit? */
+                }
+            };
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
@@ -31,10 +54,39 @@ public class PlanTaskListFragment extends Fragment implements PlanTaskListEvents
     public void eventAddTasksToPlan(View view) {
         AddTasksToPlanFragment fragment = new AddTasksToPlanFragment();
 
+        Bundle args = new Bundle();
+        args.putLong(ActivityProperties.PLAN_ID, planId);
+        fragment.setArguments(args);
+
         FragmentTransaction transaction = getFragmentManager()
                 .beginTransaction();
         transaction.replace(R.id.plan_container, fragment);
         transaction.addToBackStack(null);
         transaction.commit();
+    }
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        Bundle arguments = getArguments();
+        if (arguments != null && arguments.containsKey(ActivityProperties.PLAN_ID)) {
+            planId = (Long) arguments.get(ActivityProperties.PLAN_ID);
+        }
+
+        RecyclerView recyclerView = (RecyclerView) getActivity().findViewById(R.id.rv_create_plan_task_list);
+        recyclerView.setHasFixedSize(true);
+        recyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
+
+        taskListAdapter = new TaskRecyclerViewAdapter(taskItemClickListener);
+        recyclerView.setAdapter(taskListAdapter);
+
+        PlanTemplate planTemplate = planTemplateRepository.get(planId);
+        taskListAdapter.setTaskItems(planTemplate.getTasksWithThisPlan());
+    }
+
+    public void onResume() {
+        PlanTemplate planTemplate = planTemplateRepository.get(planId);
+        taskListAdapter.setTaskItems(planTemplate.getTasksWithThisPlan());
+        taskListAdapter.notifyDataSetChanged();
+        super.onResume();
     }
 }

--- a/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/task_list/TaskRecyclerViewAdapter.java
+++ b/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/task_list/TaskRecyclerViewAdapter.java
@@ -8,9 +8,11 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
-import database.entities.TaskTemplate;
+
 import java.util.Collections;
 import java.util.List;
+
+import database.entities.TaskTemplate;
 import pg.autyzm.friendly_plans.R;
 import pg.autyzm.friendly_plans.asset.AssetsHelper;
 
@@ -24,7 +26,7 @@ public class TaskRecyclerViewAdapter
     private TaskItemClickListener taskItemClickListener;
     private AssetsHelper assetsHelper;
 
-    TaskRecyclerViewAdapter(TaskItemClickListener taskItemClickListener) {
+    public TaskRecyclerViewAdapter(TaskItemClickListener taskItemClickListener) {
         this.taskItemClickListener = taskItemClickListener;
         this.taskItemList = Collections.emptyList();
     }
@@ -53,7 +55,7 @@ public class TaskRecyclerViewAdapter
         return taskItemList != null && taskItemList.size() != 0 ? taskItemList.size() : 0;
     }
 
-    void setTaskItems(List<TaskTemplate> taskItemList) {
+    public void setTaskItems(List<TaskTemplate> taskItemList) {
         this.taskItemList = taskItemList;
         notifyDataSetChanged();
     }
@@ -88,11 +90,16 @@ public class TaskRecyclerViewAdapter
         }
     }
 
-    TaskTemplate getTaskItem(int position) {
+    public TaskTemplate getTaskItem(int position) {
         return taskItemList.get(position);
     }
 
-    interface TaskItemClickListener {
+    public void removeListItem(int position){
+        taskItemList.remove(position);
+        notifyDataSetChanged();
+    }
+
+    public interface TaskItemClickListener {
 
         void onTaskItemClick(int position);
     }

--- a/Friendly-plans/app/src/main/res/layout/fragment_add_tasks_to_plan.xml
+++ b/Friendly-plans/app/src/main/res/layout/fragment_add_tasks_to_plan.xml
@@ -1,4 +1,9 @@
 <layout>
+  <data>
+    <variable
+        name="addTasksToPlanEvents"
+        type="pg.autyzm.friendly_plans.manager_app.view.plan_create_add_tasks.AddTasksToPlanEvents"/>
+  </data>
   <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -23,7 +28,8 @@
         android:id="@+id/id_btn_add_tasks_to_plan"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/add"/>
+        android:onClick="@{addTasksToPlanEvents::eventDoneAddingTasksToPlan}"
+        android:text="@string/done"/>
 
     </LinearLayout>
 

--- a/Friendly-plans/app/src/main/res/values/strings.xml
+++ b/Friendly-plans/app/src/main/res/values/strings.xml
@@ -32,7 +32,7 @@
   <string name="plan_create_description">Step 1: Enter plan\'s name</string>
   <string name="plan_name">Plan\'s name:</string>
   <string name="name">Name</string>
-  <string name="add">Add</string>
+  <string name="done">Done</string>
   <string name="create_plan_add_tasks_info">Step 2.2: Select tasks which you\'d like to add</string>
   <string name="plan_saved_message">Plan saved</string>
   <string name="plan_removed_message">Plan removed</string>


### PR DESCRIPTION
Allow to add tasks to plan. It works both while creating new plan, as well as, when modifying existing one. 
- New test _whenAddingNewTaskToPlanExpectShowTaskOnList_ added, along with new class _PlanTaskTemplateRule_
- Modified _PlanTemplate_ to handle **PlanTaskTemplate** @ToMany relationship
- _PlanCreateFragment_ updates plan name after clicking back button
- Changed _Save_ button do _Done_ in _AddTasksToPlanFragment_, which now works like android Back button.
- _PlanTaskListFragment_ displays updated list of tasks assigned to the plan.

TODO:
- Changing order of the tasks assigned to the plan (#277 )
- Removing selected task from plan (#315)
- Save button is not working (similar to #300 )

To discuss:
- Once the task name is clicked in the list it is added to the plan. You can't choose a tasks' set and after that accept the selection. I'm not sure if it is the best solution. 

Resolves #290, #278, #239