### PR TITLE
315 remove selected task from plan

### DIFF
--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanTaskListFragmentTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanTaskListFragmentTest.java
@@ -16,7 +16,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import database.repository.PlanTemplateRepository;
-import database.repository.TaskTemplateRepository;
 import pg.autyzm.friendly_plans.R;
 import pg.autyzm.friendly_plans.manager_app.view.plan_create.PlanCreateActivity;
 import pg.autyzm.friendly_plans.manager_app.view.plan_create_task_list.PlanTaskListFragment;
@@ -62,7 +61,7 @@ public class PlanTaskListFragmentTest {
     public void setUp() {
         Context context = activityRule.getActivity().getApplicationContext();
         PlanTemplateRepository planTemplateRepository = new PlanTemplateRepository(daoSessionResource.getSession(context));
-        
+
         long taskId = taskTemplateRule.createTask(DELETE_TEST_TASK);
         long planId = planTemplateRule.createPlan(PLAN_NAME);
         planTemplateRepository.setTasksWithThisPlan(planId, taskId);

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanTaskListFragmentTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanTaskListFragmentTest.java
@@ -43,10 +43,6 @@ public class PlanTaskListFragmentTest {
     private static final String PLAN_NAME = "PLAN NAME";
     private static final String DELETE_TEST_TASK = "DELETE TEST TASK";
 
-    private  PlanTemplateRepository planTemplateRepository;
-    private  TaskTemplateRepository taskTemplateRepository;
-    private long planId;
-
     @ClassRule
     public static DaoSessionResource daoSessionResource = new DaoSessionResource();
 
@@ -65,11 +61,11 @@ public class PlanTaskListFragmentTest {
     @Before
     public void setUp() {
         Context context = activityRule.getActivity().getApplicationContext();
-        planTemplateRepository = new PlanTemplateRepository(daoSessionResource.getSession(context));
-        taskTemplateRepository = new TaskTemplateRepository(daoSessionResource.getSession(context));
+        PlanTemplateRepository planTemplateRepository = new PlanTemplateRepository(daoSessionResource.getSession(context));
+        TaskTemplateRepository taskTemplateRepository = new TaskTemplateRepository(daoSessionResource.getSession(context));
 
         long taskId = taskTemplateRepository.create(DELETE_TEST_TASK, 1, null, null);
-        planId = planTemplateRule.createPlan(PLAN_NAME);
+        long planId = planTemplateRule.createPlan(PLAN_NAME);
         planTemplateRepository.setTasksWithThisPlan(planId, taskId);
         taskTemplateRule.createTask(TASK_NAME);
 

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanTaskListFragmentTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanTaskListFragmentTest.java
@@ -2,6 +2,7 @@ package pg.autyzm.friendly_plans.manager_app;
 
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
+import android.content.Context;
 import android.os.Bundle;
 import android.support.test.espresso.contrib.RecyclerViewActions;
 import android.support.test.rule.ActivityTestRule;
@@ -14,15 +15,19 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import database.repository.PlanTemplateRepository;
+import database.repository.TaskTemplateRepository;
 import pg.autyzm.friendly_plans.R;
 import pg.autyzm.friendly_plans.manager_app.view.plan_create.PlanCreateActivity;
 import pg.autyzm.friendly_plans.manager_app.view.plan_create_task_list.PlanTaskListFragment;
 import pg.autyzm.friendly_plans.resource.DaoSessionResource;
 import pg.autyzm.friendly_plans.resource.PlanTemplateRule;
 import pg.autyzm.friendly_plans.resource.TaskTemplateRule;
+import pg.autyzm.friendly_plans.view_actions.ViewClicker;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
@@ -36,6 +41,11 @@ public class PlanTaskListFragmentTest {
     private static final String PLAN_ID = "PLAN_ID";
     private static final String TASK_NAME = "TASK_NAME";
     private static final String PLAN_NAME = "PLAN NAME";
+    private static final String DELETE_TEST_TASK = "DELETE TEST TASK";
+
+    private  PlanTemplateRepository planTemplateRepository;
+    private  TaskTemplateRepository taskTemplateRepository;
+    private long planId;
 
     @ClassRule
     public static DaoSessionResource daoSessionResource = new DaoSessionResource();
@@ -54,10 +64,16 @@ public class PlanTaskListFragmentTest {
 
     @Before
     public void setUp() {
-        PlanTaskListFragment fragment = new PlanTaskListFragment();
+        Context context = activityRule.getActivity().getApplicationContext();
+        planTemplateRepository = new PlanTemplateRepository(daoSessionResource.getSession(context));
+        taskTemplateRepository = new TaskTemplateRepository(daoSessionResource.getSession(context));
 
+        long taskId = taskTemplateRepository.create(DELETE_TEST_TASK, 1, null, null);
+        planId = planTemplateRule.createPlan(PLAN_NAME);
+        planTemplateRepository.setTasksWithThisPlan(planId, taskId);
         taskTemplateRule.createTask(TASK_NAME);
-        long planId = planTemplateRule.createPlan(PLAN_NAME);
+
+        PlanTaskListFragment fragment = new PlanTaskListFragment();
 
         Bundle args = new Bundle();
         args.putLong(PLAN_ID, planId);
@@ -95,8 +111,27 @@ public class PlanTaskListFragmentTest {
         onView(withId(R.id.id_btn_add_tasks_to_plan))
                 .perform(click());
 
+        recyclerView = (RecyclerView) activityRule.getActivity().findViewById(R.id.rv_create_plan_task_list);
+        lastPosition = recyclerView.getAdapter().getItemCount() - 1;
+
         onView(withRecyclerView(R.id.rv_create_plan_task_list)
-                .atPosition(0))
+                .atPosition(lastPosition))
                 .check(matches(hasDescendant(withText(TASK_NAME))));
+    }
+
+    @Test
+    public void whenRemoveIconClickedExpectTaskToNoLongerBeInThisPlan(){
+        final int testedTaskPosition = 0;
+
+        onView(withId(R.id.rv_create_plan_task_list))
+                .perform(RecyclerViewActions
+                        .actionOnItemAtPosition(testedTaskPosition,
+                                new ViewClicker(R.id.id_remove_task)));
+
+        onView(withId(R.id.rv_create_plan_task_list)).perform(
+                RecyclerViewActions.scrollToPosition(testedTaskPosition));
+
+        onView(withRecyclerView(R.id.rv_create_plan_task_list)
+                .atPosition(testedTaskPosition)).check(doesNotExist());
     }
 }

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanTaskListFragmentTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanTaskListFragmentTest.java
@@ -64,7 +64,8 @@ public class PlanTaskListFragmentTest {
         PlanTemplateRepository planTemplateRepository = new PlanTemplateRepository(daoSessionResource.getSession(context));
         TaskTemplateRepository taskTemplateRepository = new TaskTemplateRepository(daoSessionResource.getSession(context));
 
-        long taskId = taskTemplateRepository.create(DELETE_TEST_TASK, 1, null, null);
+        //long taskId = taskTemplateRepository.create(DELETE_TEST_TASK, 1, null, null);
+        long taskId = taskTemplateRule.createTask(DELETE_TEST_TASK);
         long planId = planTemplateRule.createPlan(PLAN_NAME);
         planTemplateRepository.setTasksWithThisPlan(planId, taskId);
         taskTemplateRule.createTask(TASK_NAME);

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanTaskListFragmentTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanTaskListFragmentTest.java
@@ -62,9 +62,7 @@ public class PlanTaskListFragmentTest {
     public void setUp() {
         Context context = activityRule.getActivity().getApplicationContext();
         PlanTemplateRepository planTemplateRepository = new PlanTemplateRepository(daoSessionResource.getSession(context));
-        TaskTemplateRepository taskTemplateRepository = new TaskTemplateRepository(daoSessionResource.getSession(context));
-
-        //long taskId = taskTemplateRepository.create(DELETE_TEST_TASK, 1, null, null);
+        
         long taskId = taskTemplateRule.createTask(DELETE_TEST_TASK);
         long planId = planTemplateRule.createPlan(PLAN_NAME);
         planTemplateRepository.setTasksWithThisPlan(planId, taskId);

--- a/Friendly-plans/app/src/main/java/database/repository/PlanTemplateRepository.java
+++ b/Friendly-plans/app/src/main/java/database/repository/PlanTemplateRepository.java
@@ -1,8 +1,13 @@
 package database.repository;
 
+import android.util.Log;
+
+import org.greenrobot.greendao.query.QueryBuilder;
+
 import java.util.List;
 
 import database.entities.DaoSession;
+import database.entities.PlanTask;
 import database.entities.PlanTaskTemplate;
 import database.entities.PlanTaskTemplateDao;
 import database.entities.PlanTemplate;
@@ -30,7 +35,6 @@ public class PlanTemplateRepository {
         daoSession.getPlanTemplateDao().update(planTemplate);
     }
 
-
     public void setTasksWithThisPlan(Long planId, Long taskId) {
         PlanTaskTemplate planTaskTemplate = new PlanTaskTemplate();
         planTaskTemplate.setTaskTemplateId(taskId);
@@ -41,6 +45,19 @@ public class PlanTemplateRepository {
 
         get(planId).resetTasksWithThisPlan();
     }
+
+    public void deleteTaskFromThisPlan(Long planId, Long taskId){
+        PlanTaskTemplateDao planTaskTemplateDao = daoSession.getPlanTaskTemplateDao();
+        QueryBuilder<PlanTaskTemplate> queryBuilder = planTaskTemplateDao.queryBuilder();
+
+        PlanTaskTemplate planTaskTemplate = queryBuilder.where(
+                PlanTaskTemplateDao.Properties.PlanTemplateId.eq(planId),
+                PlanTaskTemplateDao.Properties.TaskTemplateId.eq(taskId))
+                .uniqueOrThrow();
+
+        planTaskTemplateDao.delete(planTaskTemplate);
+    }
+
 
     public PlanTemplate get(Long id) {
         return daoSession.getPlanTemplateDao().load(id);

--- a/Friendly-plans/app/src/main/java/database/repository/PlanTemplateRepository.java
+++ b/Friendly-plans/app/src/main/java/database/repository/PlanTemplateRepository.java
@@ -1,13 +1,11 @@
 package database.repository;
 
-import android.util.Log;
 
 import org.greenrobot.greendao.query.QueryBuilder;
 
 import java.util.List;
 
 import database.entities.DaoSession;
-import database.entities.PlanTask;
 import database.entities.PlanTaskTemplate;
 import database.entities.PlanTaskTemplateDao;
 import database.entities.PlanTemplate;

--- a/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/plan_create_add_tasks/AddTasksToPlanFragment.java
+++ b/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/plan_create_add_tasks/AddTasksToPlanFragment.java
@@ -50,8 +50,6 @@ public class AddTasksToPlanFragment extends Fragment implements AddTasksToPlanEv
                 }
             };
 
-
-
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
             Bundle savedInstanceState) {

--- a/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/plan_create_task_list/PlanTaskListFragment.java
+++ b/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/plan_create_task_list/PlanTaskListFragment.java
@@ -38,7 +38,10 @@ public class PlanTaskListFragment extends Fragment implements PlanTaskListEvents
 
                 @Override
                 public void onRemoveTaskClick(int position){
-                    /*Item remove TODO*/
+                    planTemplateRepository.deleteTaskFromThisPlan(
+                            planId,
+                            taskListAdapter.getTaskItem(position).getId());
+                    taskListAdapter.removeListItem(position);
                 }
             };
 

--- a/Friendly-plans/app/src/main/res/layout/item_task.xml
+++ b/Friendly-plans/app/src/main/res/layout/item_task.xml
@@ -57,14 +57,14 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_gravity="center_vertical"
-      android:layout_marginLeft="15dp"
+      android:layout_marginStart="15dp"
       android:orientation="vertical">
 
     <ImageButton
         android:id="@+id/id_remove_task"
         android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        app:srcCompat="@drawable/ic_delete_black_24dp" />
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_delete_black_24dp" />
   </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
Figuring out how to code a semi-proper test to this took me way too long, but #315 seems to be done.

Tasks can now be deleted from a plan by clicking the bin icon next to the task on the plan task list. 
A simple whenRemoveIconClickedExpectTaskToNoLongerBeInThisPlan test is added, though all suggestions to the way in which I did that are very much welcome. 