### PR TITLE
#301: Changed layout in fragment_task_create to TableLayout

### DIFF
--- a/Friendly-plans/app/src/main/res/layout/fragment_task_create.xml
+++ b/Friendly-plans/app/src/main/res/layout/fragment_task_create.xml
@@ -275,7 +275,7 @@
             android:text="@string/save_and_finish"
             android:layout_height="match_parent"
             android:onClick="@{events::eventSaveAndFinish}"
-            android:layout_column="0"/>
+            android:layout_column="0" />
       </TableRow>
     </TableLayout>
 


### PR DESCRIPTION
As with #302, the fragment_task_create layout has been changed to TableLayout. "Save and finish" button moved to the bottom (https://preview.uxpin.com/dc276af793ed5a347736f473bdabe8c5112f8983#/pages/87956602/simulate/sitemap?mode=i)


Resolves #185 #301