### PR TITLE
#318: FIX, Removing multiple plans now properly refreshes plan list

### DIFF
--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanListActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanListActivityTest.java
@@ -175,13 +175,17 @@ public class PlanListActivityTest {
         final int testedPlanPosition = 5;
 
         onView(withId(R.id.menu_search)).perform(typeText(expectedName + testedPlanPosition));
+        closeSoftKeyboard();
 
         onView(withId(R.id.rv_plan_list))
                 .perform(RecyclerViewActions
                         .actionOnItemAtPosition(0,
                                 new ViewClicker(R.id.id_remove_plan)));
+
+        onView(withRecyclerView(R.id.rv_plan_list)
+                .atPosition(0))
+                .check(doesNotExist());
         onView(isAssignableFrom(EditText.class)).perform(clearText());
-        closeSoftKeyboard();
 
         onView(withId(R.id.rv_plan_list)).perform(scrollToPosition(testedPlanPosition));
         onView(withRecyclerView(R.id.rv_plan_list)

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanListActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanListActivityTest.java
@@ -130,24 +130,6 @@ public class PlanListActivityTest {
     }
 
     @Test
-    public void whenSearchedPlanIsRemovedExpectNoPlansInSearch(){
-        final int testedPlanPosition = 5;
-
-        onView(withId(R.id.menu_search)).perform(typeText(expectedName + testedPlanPosition));
-        closeSoftKeyboard();
-
-        onView(withId(R.id.rv_plan_list))
-                .perform(RecyclerViewActions
-                        .actionOnItemAtPosition(0,
-                                new ViewClicker(R.id.id_remove_plan)));
-        closeSoftKeyboard();
-
-        onView(withRecyclerView(R.id.rv_plan_list)
-                .atPosition(0))
-                    .check(doesNotExist());
-    }
-
-    @Test
     public void whenSearchPlanIsRemovedExpectItToBeRemoved(){
         final int testedPlanPosition = 5;
 

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanListActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanListActivityTest.java
@@ -130,6 +130,31 @@ public class PlanListActivityTest {
     }
 
     @Test
+    public void whenMultiplePlansAreRemovedExpectListRefreshedAfterEachOneOfThem() {
+        final int testedFirstTaskPosition = 3;
+        final int testedSecondTaskPosition = 4;
+        onView(withId(R.id.rv_plan_list))
+                .perform(RecyclerViewActions
+                        .actionOnItemAtPosition(testedFirstTaskPosition,
+                                new ViewClicker(R.id.id_remove_plan)));
+        onView(withId(R.id.rv_plan_list)).perform(scrollToPosition(testedFirstTaskPosition));
+        onView(withRecyclerView(R.id.rv_plan_list)
+                .atPosition(testedFirstTaskPosition))
+                .check(matches(not(hasDescendant(withText(expectedName
+                        + testedFirstTaskPosition)))));
+
+        onView(withId(R.id.rv_plan_list))
+                .perform(RecyclerViewActions
+                        .actionOnItemAtPosition(testedSecondTaskPosition - 1,
+                                new ViewClicker(R.id.id_remove_plan)));
+        onView(withId(R.id.rv_plan_list)).perform(scrollToPosition(testedSecondTaskPosition));
+        onView(withRecyclerView(R.id.rv_plan_list)
+                .atPosition(testedSecondTaskPosition))
+                .check(matches(not(hasDescendant(withText(expectedName
+                        + testedSecondTaskPosition)))));
+    }
+
+    @Test
     public void whenSearchPlanIsRemovedExpectItToBeRemoved(){
         final int testedPlanPosition = 5;
 

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanListActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanListActivityTest.java
@@ -130,6 +130,22 @@ public class PlanListActivityTest {
     }
 
     @Test
+    public void whenSearchedPlanIsRemovedExpectNoPlansInSearch() {
+        final int testedPlanPosition = 5;
+        onView(withId(R.id.menu_search)).perform(typeText(expectedName + testedPlanPosition));
+        closeSoftKeyboard();
+        onView(withId(R.id.rv_plan_list))
+                .perform(RecyclerViewActions
+                        .actionOnItemAtPosition(0,
+                                new ViewClicker(R.id.id_remove_plan)));
+        closeSoftKeyboard();
+
+        onView(withRecyclerView(R.id.rv_plan_list)
+                .atPosition(0))
+                .check(doesNotExist());
+    }
+
+    @Test
     public void whenMultiplePlansAreRemovedExpectListRefreshedAfterEachOneOfThem() {
         final int testedFirstTaskPosition = 3;
         final int testedSecondTaskPosition = 4;

--- a/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/plan_list/PlanListActivity.java
+++ b/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/plan_list/PlanListActivity.java
@@ -40,7 +40,6 @@ public class PlanListActivity extends AppCompatActivity {
                     toastUserNotifier.displayNotifications(
                             R.string.plan_removed_message,
                             getApplicationContext());
-                    planListAdapter.setPlanItems(planTemplateRepository.getFilteredByName(searchView.getQuery().toString()));
                 }
 
                 @Override

--- a/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/plan_list/PlanListActivity.java
+++ b/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/plan_list/PlanListActivity.java
@@ -40,7 +40,7 @@ public class PlanListActivity extends AppCompatActivity {
                     toastUserNotifier.displayNotifications(
                             R.string.plan_removed_message,
                             getApplicationContext());
-                    planListAdapter.setPlanItems(planTemplateRepository.getAll());
+                    planListAdapter.setPlanItems(planTemplateRepository.getFilteredByName(searchView.getQuery().toString()));
                 }
 
                 @Override

--- a/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/plan_list/PlanListActivity.java
+++ b/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/plan_list/PlanListActivity.java
@@ -40,6 +40,7 @@ public class PlanListActivity extends AppCompatActivity {
                     toastUserNotifier.displayNotifications(
                             R.string.plan_removed_message,
                             getApplicationContext());
+                    planListAdapter.setPlanItems(planTemplateRepository.getAll());
                 }
 
                 @Override


### PR DESCRIPTION
Removing multiple plans now properly refreshes the plan list. In addition, a possibly obsolete test was removed.
"whenSearchedPlanIsRemovedExpectNoPlansInSearch" is no longer valid, as removing a plan now results in list refresh (same as in task list). As a consequence of that, after removal of the searched item, the search results are being replaced with the full plan list.