### PR TITLE
#322: deleting task is no longer possible if task is assigned to a plan

### DIFF
--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanListActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/PlanListActivityTest.java
@@ -130,22 +130,6 @@ public class PlanListActivityTest {
     }
 
     @Test
-    public void whenSearchedPlanIsRemovedExpectNoPlansInSearch() {
-        final int testedPlanPosition = 5;
-        onView(withId(R.id.menu_search)).perform(typeText(expectedName + testedPlanPosition));
-        closeSoftKeyboard();
-        onView(withId(R.id.rv_plan_list))
-                .perform(RecyclerViewActions
-                        .actionOnItemAtPosition(0,
-                                new ViewClicker(R.id.id_remove_plan)));
-        closeSoftKeyboard();
-
-        onView(withRecyclerView(R.id.rv_plan_list)
-                .atPosition(0))
-                .check(doesNotExist());
-    }
-
-    @Test
     public void whenMultiplePlansAreRemovedExpectListRefreshedAfterEachOneOfThem() {
         final int testedFirstTaskPosition = 3;
         final int testedSecondTaskPosition = 4;

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/TaskListActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/TaskListActivityTest.java
@@ -108,7 +108,6 @@ public class TaskListActivityTest {
                 .perform(RecyclerViewActions
                         .actionOnItemAtPosition(testedTaskPosition,
                                 new ViewClicker(R.id.id_remove_task)));
-//        onView(withId(R.id.rv_task_list)).perform(scrollToPosition(testedTaskPosition));
         onView(withText(R.string.task_cannot_be_removed_dialog_close_button_text)).perform(click());
         onView(withRecyclerView(R.id.rv_task_list)
                 .atPosition(testedTaskPosition))

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/TaskListActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/TaskListActivityTest.java
@@ -1,5 +1,6 @@
 package pg.autyzm.friendly_plans.manager_app;
 
+import android.content.Context;
 import android.content.Intent;
 import android.support.test.espresso.contrib.RecyclerViewActions;
 import android.support.test.rule.ActivityTestRule;
@@ -11,7 +12,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import database.repository.PlanTemplateRepository;
 import pg.autyzm.friendly_plans.R;
+import pg.autyzm.friendly_plans.resource.PlanTemplateRule;
 import pg.autyzm.friendly_plans.view_actions.ViewClicker;
 import pg.autyzm.friendly_plans.resource.DaoSessionResource;
 import pg.autyzm.friendly_plans.manager_app.view.task_list.TaskListActivity;
@@ -31,6 +34,9 @@ import static pg.autyzm.friendly_plans.matcher.RecyclerViewMatcher.withRecyclerV
 public class TaskListActivityTest {
 
     private static final String expectedName = "TEST TASK ";
+    private static final String PLAN_WITH_TASK_NAME = "PLAN WITH TASK";
+    private static final String TASK_THAT_IS_ADDED_TO_PLAN_NAME = "TASK IN PLAN";
+
     @ClassRule
     public static DaoSessionResource daoSessionResource = new DaoSessionResource();
 
@@ -42,12 +48,24 @@ public class TaskListActivityTest {
     public TaskTemplateRule taskTemplateRule = new TaskTemplateRule(daoSessionResource,
             activityRule);
 
+    @Rule
+    public PlanTemplateRule planTemplateRule = new PlanTemplateRule(daoSessionResource,
+            activityRule);
+
     @Before
     public void setUp() {
         final int numberOfTasks = 10;
         for (int taskNumber = 0; taskNumber < numberOfTasks; taskNumber++) {
             taskTemplateRule.createTask(expectedName + taskNumber);
         }
+
+        Context context = activityRule.getActivity().getApplicationContext();
+        PlanTemplateRepository planTemplateRepository = new PlanTemplateRepository(
+                daoSessionResource.getSession(context));
+        long taskId = taskTemplateRule.createTask(TASK_THAT_IS_ADDED_TO_PLAN_NAME);
+        long planId = planTemplateRule.createPlan(PLAN_WITH_TASK_NAME);
+        planTemplateRepository.setTasksWithThisPlan(planId, taskId);
+
         activityRule.launchActivity(new Intent());
     }
 
@@ -80,5 +98,20 @@ public class TaskListActivityTest {
                 .atPosition(testedTaskPosition))
                 .check(matches(not(hasDescendant(withText(expectedName
                         + testedTaskPosition)))));
+    }
+
+    @Test
+    public void whenTaskWhichIsInAPlanIsRemovedExpectTaskNotRemoved() {
+        final int testedTaskPosition = 10;
+        onView(withId(R.id.rv_task_list)).perform(scrollToPosition(testedTaskPosition));
+        onView(withId(R.id.rv_task_list))
+                .perform(RecyclerViewActions
+                        .actionOnItemAtPosition(testedTaskPosition,
+                                new ViewClicker(R.id.id_remove_task)));
+//        onView(withId(R.id.rv_task_list)).perform(scrollToPosition(testedTaskPosition));
+        onView(withText(R.string.task_cannot_be_removed_dialog_close_button_text)).perform(click());
+        onView(withRecyclerView(R.id.rv_task_list)
+                .atPosition(testedTaskPosition))
+                .check(matches(hasDescendant(withText(TASK_THAT_IS_ADDED_TO_PLAN_NAME))));
     }
 }

--- a/Friendly-plans/app/src/main/java/database/repository/PlanTemplateRepository.java
+++ b/Friendly-plans/app/src/main/java/database/repository/PlanTemplateRepository.java
@@ -3,6 +3,7 @@ package database.repository;
 
 import org.greenrobot.greendao.query.QueryBuilder;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import database.entities.DaoSession;
@@ -70,6 +71,16 @@ public class PlanTemplateRepository {
 
     public List<PlanTemplate> getAll() {
         return daoSession.getPlanTemplateDao().loadAll();
+    }
+
+    public List<PlanTemplate> getPlansWithThisTask(Long taskId) {
+        PlanTaskTemplateDao targetDao = daoSession.getPlanTaskTemplateDao();
+        List<PlanTaskTemplate> planTasks = targetDao._queryTaskTemplate_PlanTaskTemplates(taskId);
+        List<PlanTemplate> plansList = new ArrayList<>();
+        for (PlanTaskTemplate planTaskTemplate : planTasks){
+            plansList.add(planTaskTemplate.getPlanTemplate());
+        }
+        return plansList;
     }
 
     public List<PlanTemplate> getFilteredByName(String planName) {

--- a/Friendly-plans/app/src/main/java/database/repository/PlanTemplateRepository.java
+++ b/Friendly-plans/app/src/main/java/database/repository/PlanTemplateRepository.java
@@ -74,13 +74,18 @@ public class PlanTemplateRepository {
     }
 
     public List<PlanTemplate> getPlansWithThisTask(Long taskId) {
-        PlanTaskTemplateDao targetDao = daoSession.getPlanTaskTemplateDao();
-        List<PlanTaskTemplate> planTasks = targetDao._queryTaskTemplate_PlanTaskTemplates(taskId);
-        List<PlanTemplate> plansList = new ArrayList<>();
-        for (PlanTaskTemplate planTaskTemplate : planTasks){
-            plansList.add(planTaskTemplate.getPlanTemplate());
+        PlanTaskTemplateDao planTaskTemplateDao = daoSession.getPlanTaskTemplateDao();
+        List<PlanTaskTemplate> planTasks =  planTaskTemplateDao.queryBuilder()
+                .where(PlanTaskTemplateDao.Properties.TaskTemplateId.eq(taskId))
+                .list();
+        List<Long> planIds = new ArrayList<>();
+        for (PlanTaskTemplate planTask : planTasks) {
+            planIds.add(planTask.getPlanTemplateId());
         }
-        return plansList;
+        return daoSession.getPlanTemplateDao()
+                .queryBuilder()
+                .where(PlanTemplateDao.Properties.Id.in(planIds))
+                .list();
     }
 
     public List<PlanTemplate> getFilteredByName(String planName) {

--- a/Friendly-plans/app/src/main/java/database/repository/TaskTemplateRepository.java
+++ b/Friendly-plans/app/src/main/java/database/repository/TaskTemplateRepository.java
@@ -1,6 +1,8 @@
 package database.repository;
 
 import database.entities.DaoSession;
+import database.entities.PlanTaskTemplate;
+import database.entities.PlanTaskTemplateDao;
 import database.entities.TaskTemplate;
 import database.entities.TaskTemplateDao.Properties;
 import java.util.List;
@@ -43,6 +45,11 @@ public class TaskTemplateRepository {
                 .queryBuilder()
                 .where(Properties.Name.eq(taskTemplateName))
                 .list();
+    }
+
+    public List<PlanTaskTemplate> getPlansWithThisTask(Long taskId) {
+        PlanTaskTemplateDao targetDao = daoSession.getPlanTaskTemplateDao();
+        return targetDao._queryTaskTemplate_PlanTaskTemplates(taskId);
     }
 
     public List<TaskTemplate> getAll() {

--- a/Friendly-plans/app/src/main/java/database/repository/TaskTemplateRepository.java
+++ b/Friendly-plans/app/src/main/java/database/repository/TaskTemplateRepository.java
@@ -1,8 +1,6 @@
 package database.repository;
 
 import database.entities.DaoSession;
-import database.entities.PlanTaskTemplate;
-import database.entities.PlanTaskTemplateDao;
 import database.entities.TaskTemplate;
 import database.entities.TaskTemplateDao.Properties;
 import java.util.List;
@@ -45,11 +43,6 @@ public class TaskTemplateRepository {
                 .queryBuilder()
                 .where(Properties.Name.eq(taskTemplateName))
                 .list();
-    }
-
-    public List<PlanTaskTemplate> getPlansWithThisTask(Long taskId) {
-        PlanTaskTemplateDao targetDao = daoSession.getPlanTaskTemplateDao();
-        return targetDao._queryTaskTemplate_PlanTaskTemplates(taskId);
     }
 
     public List<TaskTemplate> getAll() {

--- a/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/task_list/TaskListActivity.java
+++ b/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/task_list/TaskListActivity.java
@@ -1,10 +1,16 @@
 package pg.autyzm.friendly_plans.manager_app.view.task_list;
 
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+
+import java.util.List;
+
+import database.entities.PlanTaskTemplate;
 import database.repository.TaskTemplateRepository;
 import javax.inject.Inject;
 import pg.autyzm.friendly_plans.ActivityProperties;
@@ -27,11 +33,18 @@ public class TaskListActivity extends AppCompatActivity {
 
                 @Override
                 public void onRemoveTaskClick(int position){
-                    taskTemplateRepository.delete(taskListAdapter.getTaskItem(position).getId());
-                    toastUserNotifier.displayNotifications(
-                            R.string.task_removed_message,
-                            getApplicationContext());
-                    taskListAdapter.setTaskItems(taskTemplateRepository.getAll());
+                    List<PlanTaskTemplate> planTasks = taskTemplateRepository.getPlansWithThisTask(
+                            taskListAdapter.getTaskItem(position).getId());
+                    if(planTasks.isEmpty()) {
+                        taskTemplateRepository.delete(taskListAdapter.getTaskItem(position).getId());
+                        toastUserNotifier.displayNotifications(
+                                R.string.task_removed_message,
+                                getApplicationContext());
+                        taskListAdapter.setTaskItems(taskTemplateRepository.getAll());
+                    }
+                    else{
+                        displayTaskCannotBeRemovedAlert(planTasks);
+                    }
                 }
 
                 @Override
@@ -67,5 +80,29 @@ public class TaskListActivity extends AppCompatActivity {
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
         taskListAdapter = new TaskRecyclerViewAdapter(taskItemClickListener);
         recyclerView.setAdapter(taskListAdapter);
+    }
+
+    private void displayTaskCannotBeRemovedAlert(List<PlanTaskTemplate> planTasks) {
+        String planNames = "";
+        for (PlanTaskTemplate planTask : planTasks){
+            String asd = planTask.getPlanTemplate().getName();
+            planNames = planNames + asd + ", ";
+        }
+        planNames = planNames.substring(0, planNames.length() - 2);
+        planNames += ".";
+        AlertDialog alertDialog = new AlertDialog.Builder(
+                TaskListActivity.this).create();
+        alertDialog.setTitle(R.string.break_time_tasks);
+        alertDialog.setMessage(
+                getResources().getString(R.string.task_cannot_be_removed_message)
+                        + " " + planNames);
+        alertDialog.setButton(AlertDialog.BUTTON_POSITIVE,
+                getResources().getString(R.string.task_cannot_be_removed_dialog_close_button_text),
+                new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int which) {
+                        dialog.dismiss();
+                    }
+                });
+        alertDialog.show();
     }
 }

--- a/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/notifications/DialogUserNotifier.java
+++ b/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/notifications/DialogUserNotifier.java
@@ -1,0 +1,27 @@
+package pg.autyzm.friendly_plans.notifications;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+
+public class DialogUserNotifier {
+    AlertDialog alertDialog;
+
+    public DialogUserNotifier(Context context, String title, String message, String buttonText){
+        alertDialog = new AlertDialog.Builder(
+                context).create();
+        alertDialog.setTitle(title);
+        alertDialog.setMessage(message);
+        alertDialog.setButton(AlertDialog.BUTTON_POSITIVE,
+                buttonText,
+                new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int which) {
+                        dialog.dismiss();
+                    }
+                });
+    }
+
+    public void showDialog() {
+        alertDialog.show();
+    }
+}

--- a/Friendly-plans/app/src/main/res/values/strings.xml
+++ b/Friendly-plans/app/src/main/res/values/strings.xml
@@ -40,6 +40,9 @@
   <string name="break_time_tasks">Break time tasks</string>
   <string name="task_saved_message">Task saved</string>
   <string name="task_removed_message">Task removed</string>
+  <string name="task_cannot_be_removed">Task cannot be removed</string>
+  <string name="task_cannot_be_removed_message">Task cannot be removed because it is assigned to the following plans: </string>
+  <string name="task_cannot_be_removed_dialog_close_button_text">Close</string>
   <string name="task_with_steps_saved_message">Task with steps saved</string>
   <string name="step_removed_message">Step removed</string>
   <string name="step_saved_message">Step saved</string>


### PR DESCRIPTION
AlertDialog is displayed when trying to delete the assigned task. List of plans to which it is assigned is displayed. Added whenTaskWhichIsInAPlanIsRemovedExpectTaskNotRemoved test.
Additionally deleted unnecessary test as asked [here](https://github.com/autyzm-pg/friendly-plans/pull/338/files/e7700e60a89ea3eb890d11aa86bbc68eeb5b8e40..a0abb2b5ef905cfb57a961900fdd858c7af01d9c#diff-eb136ab45cd70ac60fe6adfba8491b6f), as I overlooked it previously.

I can create a simple Dialog class extending from AlertDialog in pg.autyzm.friendly_plans.notifications for the use in other areas of the project if you find that useful. As for now I just created a simple AlertDialog where I need it, as I didn't find anything in the project that could be used for that purpose.