### PR TITLE
#329: navigate to first screen after saving steps list

### DIFF
--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/StepListFragmentTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/StepListFragmentTest.java
@@ -58,15 +58,11 @@ public class StepListFragmentTest {
     @Before
     public void setUp() {
         long taskId = taskTemplateRule.createTaskWithSteps(TASK_NAME_1, STEP_NAME_1, STEP_NAME_2);
-
         openStepsListFragment(taskId);
     }
 
     @Test
     public void whenTaskHasStepsExpectStepsToBeDisplayed() {
-        long taskId = taskTemplateRule.createTaskWithSteps(TASK_NAME_1, STEP_NAME_1, STEP_NAME_2);
-        openStepsListFragment(taskId);
-
         assertStepDisplayed(0, STEP_NAME_1);
         assertStepDisplayed(1, STEP_NAME_2);
     }
@@ -81,8 +77,6 @@ public class StepListFragmentTest {
 
     @Test
     public void whenSaveClickedTaskCreateActivityShouldBeDisplayed() {
-        long taskId = taskTemplateRule.createTaskWithSteps(TASK_NAME_1, STEP_NAME_1, STEP_NAME_2);
-        openStepsListFragment(taskId);
         onView(withId(R.id.id_btn_next))
             .perform(click());
 
@@ -91,9 +85,6 @@ public class StepListFragmentTest {
 
     @Test
     public void whenStepIsRemovedExpectStepIsNotOnTheList() {
-        long taskId = taskTemplateRule.createTaskWithSteps(TASK_NAME_1, STEP_NAME_1, STEP_NAME_2);
-        openStepsListFragment(taskId);
-
         onView(withId(R.id.rv_step_list)).perform(
                 RecyclerViewActions
                         .actionOnItemAtPosition(0, clickChildViewWithId(R.id.id_remove_step)));
@@ -104,9 +95,6 @@ public class StepListFragmentTest {
 
     @Test
     public void whenStepRemoveIconIsClickedButNoConfirmationGivenExpectStepIsOnTheList() {
-        long taskId = taskTemplateRule.createTaskWithSteps(TASK_NAME_1, STEP_NAME_1, STEP_NAME_2);
-        openStepsListFragment(taskId);
-
         onView(withId(R.id.rv_step_list)).perform(
                 RecyclerViewActions
                         .actionOnItemAtPosition(0, clickChildViewWithId(R.id.id_remove_step)));
@@ -117,9 +105,6 @@ public class StepListFragmentTest {
 
     @Test
     public void whenStepIsRemovedBySwipeExpectStepIsNotOnTheList() {
-        long taskId = taskTemplateRule.createTaskWithSteps(TASK_NAME_1, STEP_NAME_1, STEP_NAME_2);
-        openStepsListFragment(taskId);
-
         onView(withId(R.id.rv_step_list)).perform(
                 RecyclerViewActions
                         .actionOnItemAtPosition(0, swipeLeft()));
@@ -130,9 +115,6 @@ public class StepListFragmentTest {
 
     @Test
     public void whenStepIsClickedEditStepIsOpened() {
-        long taskId = taskTemplateRule.createTaskWithSteps(TASK_NAME_1, STEP_NAME_1, STEP_NAME_2);
-        openStepsListFragment(taskId);
-
         onView(withId(R.id.rv_step_list)).perform(
                 RecyclerViewActions
                         .actionOnItemAtPosition(0, click()));
@@ -149,6 +131,7 @@ public class StepListFragmentTest {
         FragmentManager manager = activityRule.getActivity().getFragmentManager();
         FragmentTransaction transaction = manager.beginTransaction();
         transaction.replace(R.id.task_container, fragment);
+        transaction.addToBackStack(null);
         transaction.commit();
     }
 

--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/StepListFragmentTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/StepListFragmentTest.java
@@ -80,13 +80,13 @@ public class StepListFragmentTest {
     }
 
     @Test
-    public void whenSaveAndFinishClickedMainMenuShouldBeDisplayed() {
+    public void whenSaveClickedTaskCreateActivityShouldBeDisplayed() {
         long taskId = taskTemplateRule.createTaskWithSteps(TASK_NAME_1, STEP_NAME_1, STEP_NAME_2);
         openStepsListFragment(taskId);
         onView(withId(R.id.id_btn_next))
             .perform(click());
 
-        onView(withId(R.id.button_createPlan)).check(matches(isDisplayed()));
+        onView(withId(R.id.id_btn_steps)).check(matches(isDisplayed()));
     }
 
     @Test

--- a/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/step_list/StepListFragment.java
+++ b/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/step_list/StepListFragment.java
@@ -158,12 +158,7 @@ public class StepListFragment extends Fragment implements StepListEvents {
         toastUserNotifier.displayNotifications(
                 R.string.task_with_steps_saved_message,
                 getActivity().getApplicationContext());
-        showMainMenu();
-    }
-
-    private void showMainMenu() {
-        Intent intent = new Intent(getActivity(), MainActivity.class);
-        startActivity(intent);
+        getActivity().getFragmentManager().popBackStackImmediate();
     }
 
     private void removeStep(long stepId){

--- a/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/step_list/StepListFragment.java
+++ b/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/step_list/StepListFragment.java
@@ -158,7 +158,7 @@ public class StepListFragment extends Fragment implements StepListEvents {
         toastUserNotifier.displayNotifications(
                 R.string.task_with_steps_saved_message,
                 getActivity().getApplicationContext());
-        getActivity().getFragmentManager().popBackStackImmediate();
+        getActivity().getFragmentManager().popBackStack();
     }
 
     private void removeStep(long stepId){

--- a/Friendly-plans/app/src/main/res/layout/fragment_step_list.xml
+++ b/Friendly-plans/app/src/main/res/layout/fragment_step_list.xml
@@ -29,12 +29,13 @@
         android:layout_height="wrap_content"
         android:onClick="@{stepListEvents::eventCreateStep}"
         android:text="@string/create_step"/>
+
       <Button
-        android:id="@+id/id_btn_next"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:onClick="@{stepListEvents::eventSaveAndFinish}"
-        android:text="@string/save_and_finish"/>
+          android:id="@+id/id_btn_next"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:onClick="@{stepListEvents::eventSaveAndFinish}"
+          android:text="@string/save" />
 
     </LinearLayout>
 


### PR DESCRIPTION
#329 The "save and finish" button on the steps list is now changed to "save" as suggested and it takes the user back to the task creation list, same as with tasks and plan creation. 

Test that checked if it went back to the main menu was changed to check if it goes back to task creation, though I have no clue why in Espresso it does not. It works great if a user is clicking the button, but for some weird reason in Espresso it does not go back to the task creation activity. Perhaps it is a bug in Espresso itself? I have used an exact same logic as in the previous test.
Should I create a separate issue for that and remove the test from that pull request? Or maybe someone has an idea why it would work in reality but not in Espresso. Google gives me nothing. 

//Edit: just noticed, that it is was not @paulamoller who marked this issue as "Alfa Scope Proposal", sorry if it is not intended to work like this after all, feel free to reject the PR in that case :P 