### PR TITLE
#298: Select active child

### DIFF
--- a/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/ChildListActivityTest.java
+++ b/Friendly-plans/app/src/androidTest/java/pg/autyzm/friendly_plans/manager_app/ChildListActivityTest.java
@@ -15,6 +15,7 @@ import static org.hamcrest.core.Is.is;
 import static pg.autyzm.friendly_plans.matcher.RecyclerViewMatcher.withRecyclerView;
 
 import android.content.Context;
+import android.support.test.espresso.contrib.RecyclerViewActions;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.view.WindowManager;
@@ -114,12 +115,44 @@ public class ChildListActivityTest {
 
     @Test
     public void whenChildIsAddedToDBExpectProperlyDisplayedOnRecyclerView() {
-
         final int testedChildPosition = 5;
+        closeSoftKeyboard();
         onView(withId(R.id.rv_child_list)).perform(scrollToPosition(testedChildPosition));
         onView(withRecyclerView(R.id.rv_child_list)
                 .atPosition(testedChildPosition))
                 .check(matches(hasDescendant(withText(EXPECTED_FIRST_NAME + " " + EXPECTED_LAST_NAME
                         + testedChildPosition))));
+    }
+
+    @Test
+    public void whenChildIsClickedAndSelectedExpectDBChildStatusChangeToActive() {
+        final int testedChildPosition = 5;
+        closeSoftKeyboard();
+        onView(withId(R.id.rv_child_list))
+                .perform(RecyclerViewActions.actionOnItemAtPosition(testedChildPosition, click()));
+        onView(withId(R.id.id_set_active_child)).perform(click());
+
+        List<Child> child = childRepository.getBySurname(EXPECTED_LAST_NAME + testedChildPosition);
+        assertThat(child.get(0).getIsActive(), is(true));
+    }
+
+    @Test
+    public void whenOtherChildIsSelectedActiveExpectPreviousActiveChildNoLongerActiveInDB(){
+        final int firstTestedChildPosition = 5;
+        final int secondTestedChildPosition = 6;
+        closeSoftKeyboard();
+        onView(withId(R.id.rv_child_list))
+                .perform(RecyclerViewActions.actionOnItemAtPosition(firstTestedChildPosition, click()));
+        onView(withId(R.id.id_set_active_child)).perform(click());
+
+        onView(withId(R.id.button_addRemoveChild)).perform(click());
+
+        closeSoftKeyboard();
+        onView(withId(R.id.rv_child_list))
+                .perform(RecyclerViewActions.actionOnItemAtPosition(secondTestedChildPosition, click()));
+        onView(withId(R.id.id_set_active_child)).perform(click());
+
+        List<Child> child2 = childRepository.getBySurname(EXPECTED_LAST_NAME + firstTestedChildPosition);
+        assertThat(child2.get(0).getIsActive(), is(false));
     }
 }

--- a/Friendly-plans/app/src/main/AndroidManifest.xml
+++ b/Friendly-plans/app/src/main/AndroidManifest.xml
@@ -40,7 +40,8 @@
       android:screenOrientation="landscape"/>
     <activity
       android:name=".manager_app.view.child_list.ChildListActivity"
-      android:screenOrientation="landscape"/>
+      android:screenOrientation="landscape"
+        android:windowSoftInputMode="adjustPan"/>
     <activity
       android:name=".view.child_settings.ChildSettingsActivity"
       android:screenOrientation="landscape"/>

--- a/Friendly-plans/app/src/main/java/database/entities/Child.java
+++ b/Friendly-plans/app/src/main/java/database/entities/Child.java
@@ -19,6 +19,8 @@ public class Child {
 
     private String surname;
 
+    private boolean isActive;
+
     private String fontSize;
 
     private String pictureSize;
@@ -40,12 +42,13 @@ public class Child {
     @Generated(hash = 1911343815)
     private transient ChildDao myDao;
 
-    @Generated(hash = 1302308560)
-    public Child(Long id, String name, String surname, String fontSize, String pictureSize,
-            String displayMode) {
+    @Generated(hash = 212691019)
+    public Child(Long id, String name, String surname, boolean isActive, String fontSize,
+            String pictureSize, String displayMode) {
         this.id = id;
         this.name = name;
         this.surname = surname;
+        this.isActive = isActive;
         this.fontSize = fontSize;
         this.pictureSize = pictureSize;
         this.displayMode = displayMode;
@@ -167,6 +170,14 @@ public class Child {
             throw new DaoException("Entity is detached from DAO context");
         }
         myDao.update(this);
+    }
+
+    public boolean getIsActive() {
+        return this.isActive;
+    }
+
+    public void setIsActive(boolean isActive) {
+        this.isActive = isActive;
     }
 
     /** called by internal mechanisms, do not call yourself. */

--- a/Friendly-plans/app/src/main/java/database/repository/ChildRepository.java
+++ b/Friendly-plans/app/src/main/java/database/repository/ChildRepository.java
@@ -17,6 +17,7 @@ public class ChildRepository {
         Child childTemplate = new Child();
         childTemplate.setName(firstName);
         childTemplate.setSurname(lastName);
+        childTemplate.setIsActive(false);
         return daoSession.getChildDao().insert(childTemplate);
     }
 

--- a/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/child_list/ChildListActivity.java
+++ b/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/child_list/ChildListActivity.java
@@ -1,5 +1,6 @@
 package pg.autyzm.friendly_plans.manager_app.view.child_list;
 
+import android.content.Intent;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -7,11 +8,18 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
+import android.view.View;
+import android.widget.Button;
+
+import java.util.List;
+
+import database.entities.Child;
 import database.repository.ChildRepository;
 import javax.inject.Inject;
 import pg.autyzm.friendly_plans.App;
 import pg.autyzm.friendly_plans.R;
 import pg.autyzm.friendly_plans.databinding.ActivityChildListBinding;
+import pg.autyzm.friendly_plans.manager_app.view.main_screen.MainActivity;
 import pg.autyzm.friendly_plans.notifications.ToastUserNotifier;
 
 public class ChildListActivity extends AppCompatActivity implements ChildListActivityEvents {
@@ -23,6 +31,23 @@ public class ChildListActivity extends AppCompatActivity implements ChildListAct
     ToastUserNotifier toastUserNotifier;
 
     ChildListData childData;
+    private ChildRecyclerViewAdapter childListAdapter;
+    private Integer selectedChildPosition;
+
+    ChildRecyclerViewAdapter.ChildItemClickListener childItemClickListener =
+            new ChildRecyclerViewAdapter.ChildItemClickListener() {
+
+                @Override
+                public void onChildItemClick(int position){
+                    childListAdapter.setSelectedChildPosition(position);
+                    selectedChildPosition = position;
+                }
+
+                @Override
+                public void onRemoveChildClick(long itemId){
+                    //TODO
+                }
+            };
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -41,16 +66,24 @@ public class ChildListActivity extends AppCompatActivity implements ChildListAct
         binding.setChildListData(childData);
 
         setUpViews();
-
     }
 
     private void setUpViews() {
         RecyclerView recyclerView = (RecyclerView) findViewById(R.id.rv_child_list);
         recyclerView.setHasFixedSize(true);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
-        ChildRecyclerViewAdapter childListAdapter = new ChildRecyclerViewAdapter();
+        childListAdapter = new ChildRecyclerViewAdapter(childItemClickListener);
         recyclerView.setAdapter(childListAdapter);
         childListAdapter.setChildItems(childRepository.getAll());
+
+        Button setActiveChildButton = (Button) findViewById(R.id.id_set_active_child);
+        setActiveChildButton.setOnClickListener(new View.OnClickListener() {
+            public void onClick(View v) {
+                setActiveChild();
+                Intent intent = new Intent(ChildListActivity.this, MainActivity.class);
+                startActivity(intent);
+            }
+        });
     }
 
     @Override
@@ -68,6 +101,14 @@ public class ChildListActivity extends AppCompatActivity implements ChildListAct
         } catch (RuntimeException exception) {
             return handleSavingError(exception);
         }
+    }
+
+    private void setActiveChild(){
+        List<Child> childList = childRepository.getAll();
+        for (Child child : childList)
+            if(child.getIsActive())
+                child.setIsActive(false);
+        childListAdapter.getChild(selectedChildPosition).setIsActive(true);
     }
 
     @Nullable

--- a/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/child_list/ChildRecyclerViewAdapter.java
+++ b/Friendly-plans/app/src/main/java/pg/autyzm/friendly_plans/manager_app/view/child_list/ChildRecyclerViewAdapter.java
@@ -1,9 +1,11 @@
 package pg.autyzm.friendly_plans.manager_app.view.child_list;
 
+import android.graphics.Color;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageButton;
 import android.widget.TextView;
 import database.entities.Child;
 import java.util.Collections;
@@ -14,9 +16,19 @@ public class ChildRecyclerViewAdapter extends
         RecyclerView.Adapter<ChildRecyclerViewAdapter.ChildListViewHolder> {
 
     private List<Child> childItemList;
+    private ChildItemClickListener childItemClickListener;
+    private Integer selectedChildPosition;
 
-    ChildRecyclerViewAdapter() {
+    ChildRecyclerViewAdapter(ChildItemClickListener childItemClickListener) {
+        this.childItemClickListener = childItemClickListener;
         this.childItemList = Collections.emptyList();
+    }
+
+    interface ChildItemClickListener {
+
+        void onChildItemClick(int position);
+
+        void onRemoveChildClick(long itemId);
     }
 
     @Override
@@ -24,7 +36,8 @@ public class ChildRecyclerViewAdapter extends
             int viewType) {
         View view = LayoutInflater.from(parent.getContext())
                 .inflate(R.layout.item_child, parent, false);
-        return new ChildRecyclerViewAdapter.ChildListViewHolder(view);
+        return new ChildRecyclerViewAdapter.ChildListViewHolder(view, childItemClickListener,
+                childItemList);
     }
 
     @Override
@@ -33,6 +46,10 @@ public class ChildRecyclerViewAdapter extends
         if (childItemList != null && !childItemList.isEmpty()) {
             Child childItem = childItemList.get(position);
             holder.childName.setText(childItem.getName() + " " + childItem.getSurname());
+            if(selectedChildPosition != null && selectedChildPosition == position)
+                holder.itemView.setBackgroundColor(Color.parseColor("#cccccc"));
+            else
+                holder.itemView.setBackgroundColor(Color.TRANSPARENT);
         }
     }
 
@@ -41,19 +58,53 @@ public class ChildRecyclerViewAdapter extends
         return childItemList != null && childItemList.size() != 0 ? childItemList.size() : 0;
     }
 
+    Child getChild(int position) {
+        return childItemList.get(position);
+    }
+
     void setChildItems(List<Child> childItemList) {
         this.childItemList = childItemList;
+        notifyDataSetChanged();
+    }
+
+    void setSelectedChildPosition(int selectedChildPosition) {
+        this.selectedChildPosition = selectedChildPosition;
         notifyDataSetChanged();
     }
 
     static class ChildListViewHolder extends RecyclerView.ViewHolder {
 
         TextView childName;
+        ImageButton removeButton;
+        ChildItemClickListener childItemClickListener;
+        List<Child> childItemList;
 
-        ChildListViewHolder(View itemView) {
+        View.OnClickListener deleteButtonListener = new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                long id = childItemList.get(getAdapterPosition()).getId();
+                childItemClickListener.onRemoveChildClick(id);
+            }
+        };
+
+        View.OnClickListener selectItemListener = new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                childItemClickListener.onChildItemClick(getAdapterPosition());
+            }
+        };
+
+        ChildListViewHolder(View itemView, ChildItemClickListener childItemClickListener,
+                            List<Child> childItemList) {
             super(itemView);
             this.childName = (TextView) itemView
                     .findViewById(R.id.id_tv_child_name);
+            this.removeButton = (ImageButton) itemView
+                    .findViewById(R.id.id_remove_child);
+            this.childItemList = childItemList;
+            this.childItemClickListener = childItemClickListener;
+            this.removeButton.setOnClickListener(deleteButtonListener);
+            itemView.setOnClickListener(selectItemListener);
         }
     }
 }

--- a/Friendly-plans/app/src/main/res/layout/activity_child_list.xml
+++ b/Friendly-plans/app/src/main/res/layout/activity_child_list.xml
@@ -74,16 +74,40 @@
         android:src="@drawable/ic_add_black" />
 
     </GridLayout>
-    <android.support.v7.widget.RecyclerView
-      android:id="@+id/rv_child_list"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="110dp"
-      android:layout_alignParentStart="true"
-      android:layout_alignParentTop="true"
-      android:layout_columnSpan="4"
-      android:layout_row="2"
-      android:scrollbars="vertical"
-      tools:listitem="@layout/item_child"></android.support.v7.widget.RecyclerView>
+
+      <android.support.v7.widget.RecyclerView
+          android:id="@+id/rv_child_list"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_alignParentStart="true"
+          android:layout_alignParentTop="true"
+          android:layout_columnSpan="4"
+          android:layout_marginBottom="60dp"
+          android:layout_marginTop="100dp"
+          android:layout_row="2"
+          android:scrollbars="vertical"
+          tools:listitem="@layout/item_child"></android.support.v7.widget.RecyclerView>
+
+
+    <GridLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="5dp"
+        android:alignmentMode="alignBounds"
+        android:columnCount="5"
+        android:orientation="vertical"
+        android:stretchMode="columnWidth"
+        android:windowSoftInputMode="adjustNothing">
+
+      <Button
+        android:id="@+id/id_set_active_child"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_column="4"
+        android:layout_row="1"
+          android:text="@string/select_active_child_button"/>
+
+    </GridLayout>
+
   </RelativeLayout>
 </layout>

--- a/Friendly-plans/app/src/main/res/values/strings.xml
+++ b/Friendly-plans/app/src/main/res/values/strings.xml
@@ -25,7 +25,7 @@
   <string name="main_list_of_plans_edit_plan">List of Plans / Edit Plan</string>
   <string name="main_list_of_tasks_edit_task">List of Tasks / Edit Task</string>
   <string name="main_active_child_settings">Active Child Settings</string>
-  <string name="main_add_remove_child">Add / Remove Child</string>
+  <string name="main_add_remove_child">Add/Choose active child</string>
   <string name="main_change_active_child">Change Active Child</string>
   <string name="main_create_plan">Create Plan</string>
   <string name="main_activate_plan">Activate Plan</string>
@@ -66,6 +66,7 @@
   <string name="child_settings_change">Change child\'s settings</string>
   <string name="child_name">Name:</string>
   <string name="child_surname">Surname:</string>
+  <string name="select_active_child_button">Select</string>
   <string name="font_size">Font size:</string>
   <string name="task_mode">Task\'s mode:</string>
   <string name="step_mode">Step\'s mode:</string>
@@ -76,7 +77,7 @@
   <string name="list">List</string>
   <string name="slide">Slide</string>
   <string name="select">Select</string>
-  <string name="child_list_description">Add new child by entering it\'s first name and last name or remove existing one</string>
+  <string name="child_list_description">Add new child, remove existing one or select from the list which one should be active</string>
   <string name="child_first_name">First name:</string>
   <string name="child_last_name">Last name:</string>
   <string name="child_saved_message">Child profile saved</string>


### PR DESCRIPTION
The ability to select an active child in "Add / remove child" section was added.
Section was renamed to "Add/Choose active child", as suggested in https://preview.uxpin.com/dc276af793ed5a347736f473bdabe8c5112f8983#/pages/87956056/simulate/sitemap?mode=i . 

I once again struggle with Espresso though - tests were added but Espresso doesn't let them through, despite them working great on production.
Having two brakpoints, in line 110 and 111 of ChildListActivity.java (setActiveChild()), we can see, that if we set any child to active, we will hit the 111 line breakpoint. Then if we set another child to active (meaning we change the active child, as there can only be one at a time), we struck both breakpoints one after another (110 and 111). That proves that the previous one was set correctly. 

That does not replicate in espresso though, during assertion Child.isActive is always false (and always hits only 111 during setting child active). Just as if there were 2 separate databases used - one during action and other during assertion or something wild like that.

Returning to the previous activity isn't an issue this time, as I tried removing it and it didn't help.

Apart from that everything seems to work fine and the rest of the tests are going through.